### PR TITLE
ci: fix Node.js 20 deprecation warnings in release and versioning workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,25 +10,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Import GPG key
         id: import_gpg
-        uses: paultyng/ghaction-import-gpg@v2.1.0
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --clean

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -21,7 +21,7 @@ jobs:
       # Generate a token from GitHub App
       - name: Generate GitHub App Token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.SPS_RELEASE_APP_ID }}
           private-key: ${{ secrets.SPS_RELEASE_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Upgrade GitHub Actions in `release.yml` and `versioning.yml` to Node.js 22+/24+ compatible versions, fixing the deprecation warnings flagged in #14

### release.yml
| Action | Before | After | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | Also replaces separate "Unshallow" step with `fetch-depth: 0` |
| `actions/setup-go` | v5 | **v6** | |
| `paultyng/ghaction-import-gpg` | v2.1.0 | **crazy-max/ghaction-import-gpg@v7** | paultyng is deprecated; switched from env vars to `with:` inputs |
| `goreleaser/goreleaser-action` | v2 | **v7** | |

### versioning.yml
| Action | Before | After |
|---|---|---|
| `actions/create-github-app-token` | v1 | **v3** |

### Not changed
- **`googleapis/release-please-action@v4`** — no Node 24 version available yet ([upstream issue](https://github.com/googleapis/release-please-action/issues/1162))
- **`ci.yml`** and **`codeql.yml`** — already on latest versions

## Test plan
- [x] Verify no untrusted input is used in `run:` blocks (security review)
- [x] GPG import step output (`fingerprint`) is still referenced correctly by GoReleaser
- [ ] Trigger a test release tag to validate the full release pipeline