### PR TITLE
ci: revert skip-github-release flag in release-please config

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,7 +1,6 @@
 {
   "release-type": "simple",
   "include-v-in-tag": true,
-  "skip-github-release": true,
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
Reverts the `skip-github-release: true` option added in c383365.

The flag was intended to prevent release-please from creating an empty GitHub Release before GoReleaser attaches artifacts. However, it also suppresses tag creation and breaks release-please state tracking: release-please outputs no `release_created` or `tag_name`, and on subsequent runs aborts with "untagged, merged release PRs outstanding".

Without this flag, release-please creates both the tag and the GitHub Release. GoReleaser then triggers on the tag push and populates the release with signed binaries. This is the standard Terraform provider release flow and avoids the need for manual tag creation.