### PR TITLE
ci: decouple tagging from release-please

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,37 @@
+name: Tag Release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+
+permissions: {}
+
+jobs:
+  tag:
+    if: >-
+      github.event.pull_request.merged &&
+      startsWith(github.event.pull_request.head.ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.SPS_RELEASE_APP_ID }}
+          private-key: ${{ secrets.SPS_RELEASE_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Create and push tag
+        run: |
+          VERSION=$(jq -r '."."' .release-please-manifest.json)
+          TAG="v${VERSION}"
+          echo "::notice::Creating tag ${TAG}"
+          git tag "${TAG}"
+          git push origin "${TAG}"

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,6 +1,7 @@
 {
   "release-type": "simple",
   "include-v-in-tag": true,
+  "skip-github-release": true,
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
## Summary

- Re-adds `skip-github-release: true` to release-please config so it only manages the version-bump PR and changelog
- Adds a new `tag-release.yml` workflow that creates a git tag when a release-please PR is merged
- The tag push triggers the existing `release.yml` where GoReleaser creates the GitHub Release with signed artifacts in one atomic step

## Problem

release-please creates an empty GitHub Release before GoReleaser attaches artifacts. The Terraform Registry picks up this empty release, requiring manual resync. Setting `skip-github-release: true` prevents this but also suppresses tag creation, breaking both the release pipeline and release-please state tracking (`untagged, merged release PRs outstanding`).

## How it works now

1. **Versioning workflow** → release-please creates/updates version-bump PR (no release, no tag)
2. **Tag Release workflow** → on merge of release-please PR, reads version from manifest, creates and pushes `v*` tag using GitHub App token
3. **Release workflow** → triggered by tag push, GoReleaser builds binaries, signs with GPG, creates GitHub Release with all artifacts

## Test plan

- [ ] Merge this PR
- [ ] Verify next release-please PR merge triggers `tag-release.yml`
- [ ] Verify tag creation triggers `release.yml` (GoReleaser)
- [ ] Verify Terraform Registry picks up the release with artifacts