### PR TITLE
ci: change release-please strategy from simple to go

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "release-type": "simple",
+  "release-type": "go",
   "include-v-in-tag": true,
   "packages": {
     ".": {}


### PR DESCRIPTION
## Summary

- Changes `release-type` from `simple` to `go` in release-please config

## Problem

The `simple` strategy always bumps the patch version (0.0.x) regardless of conventional commit type. `feat:` commits that should trigger a minor bump (0.x.0) were only producing patch bumps.

## Fix

The `go` strategy respects conventional commits:
- `fix:` → patch (0.0.x)
- `feat:` → minor (0.x.0)
- `feat!:` / `BREAKING CHANGE:` → major (x.0.0)

## Test plan

- [ ] Verify next release-please PR shows correct version bump based on commit types