### PR TITLE
chore: bump Go 1.24.3 → 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-spaceship
 
-go 1.24.3
+go 1.25.9
 
 require (
 	github.com/dlclark/regexp2 v1.11.5


### PR DESCRIPTION
## Summary

Bump Go from 1.24.3 to 1.25.9 (released April 7, 2026) with security and bug fixes.

Only `go.mod` needed updating — CI workflows already use `go-version-file: go.mod`.

## Test plan

- [x] `go build .` passes
- [x] `make test` — all unit tests pass
- [x] CI green