### PR TITLE
ci: add Codecov coverage upload to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
                   path: coverage.out
                   retention-days: 30
 
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v6
+              with:
+                  files: coverage.out
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  fail_ci_if_error: false
+
             - name: Validate Documentation
               run: |
                   make docs


### PR DESCRIPTION
## Summary

Add Codecov upload step to the CI workflow so coverage reports are tracked and the codecov badge displays coverage percentage.

The `coverage.out` file is already generated by the `make test-cover` step — this adds the `codecov/codecov-action@v6` upload after the existing artifact upload.

**Note:** Requires `CODECOV_TOKEN` secret to be configured in repo settings (Settings → Secrets → Actions). Get the token from the [Codecov dashboard](https://app.codecov.io/) for this repo.

## Test plan

- [x] CI green
- [x] Verify codecov upload succeeds after CODECOV_TOKEN is configured