### PR TITLE
chore: add git privacy rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,10 @@ After making changes, follow this order:
 - Internal design notes live in `internal/docs/`.
 - Provider reads `SPACESHIP_API_KEY` / `SPACESHIP_API_SECRET` env vars or inline HCL attributes.
 
+## Git privacy
+
+Before creating git commits, verify the current `git config user.email` is a GitHub noreply address (matching `*@users.noreply.github.com`). If it is not, look up the user's GitHub ID and username via `gh api user` and set it to `<id>+<username>@users.noreply.github.com` using `git config user.email`.
+
 ## Key design rules
 
 - **DNS records are scoped to the custom group**: The API returns records across three DNS groups: `custom`, `product`, and `personalNS`. The provider only manages `custom` group records. Do not touch records in other groups.


### PR DESCRIPTION
## Summary
- Add a "Git privacy" section to CLAUDE.md instructing Claude Code to use GitHub noreply email addresses when committing
- Prevents accidental exposure of contributors' real email addresses in git history

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm Claude Code picks up the new rule in future sessions