### PR TITLE
fix(ci): use default GITHUB_TOKEN for PR title check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,16 +12,9 @@ jobs:
     name: Conventional PR Title
     runs-on: ubuntu-latest
     steps:
-      - name: Generate GitHub App Token
-        id: generate-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.SPS_RELEASE_APP_ID }}
-          private-key: ${{ secrets.SPS_RELEASE_PRIVATE_KEY }}
-
       - uses: amannn/action-semantic-pull-request@v5
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           types: |
             feat


### PR DESCRIPTION
## Summary
- Remove GitHub App token generation step from PR title check workflow
- Use the built-in `GITHUB_TOKEN` which already has `pull-requests: read` permission
- Fixes the failing "Conventional PR Title" CI check caused by missing/expired app credentials

## Test plan
- [x] Verify this PR's own "Conventional PR Title" check passes