### PR TITLE
chore: add git privacy recommendation to CLAUDE.md and CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ After making changes, follow this order:
 
 ## Git privacy
 
-Before creating git commits, verify the current `git config user.email` is a GitHub noreply address (matching `*@users.noreply.github.com`). If it is not, look up the user's GitHub ID and username via `gh api user` and set it to `<id>+<username>@users.noreply.github.com` using `git config user.email`.
+Before creating git commits, check that `git config user.email` is set. If it is not configured, suggest the contributor set one. Do not override an already-configured email.
 
 ## Key design rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,19 @@ make testacc
 6. Ensure CI passes. Acceptance tests run automatically when secrets are
    available.
 
+### Git Email Privacy
+
+To keep your personal email out of the public git history, consider using a GitHub noreply address.
+You can enable this in [GitHub Settings → Emails](https://github.com/settings/emails) by checking **"Keep my email addresses private"**. Your noreply address follows the format `<id>+<username>@users.noreply.github.com` and is shown on that page.
+
+To use it for this repo:
+
+```shell
+$ git config user.email "YOUR_ID+YOUR_USERNAME@users.noreply.github.com"
+```
+
+This is optional — use whichever email you prefer.
+
 ### Commit Messages
 
 Use [Conventional Commits](https://www.conventionalcommits.org/) format:


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: add soft git privacy rule — only check that `user.email` is set, never override
- **CONTRIBUTING.md**: add optional recommendation to use GitHub noreply email

Supersedes #51.

## Test plan
- [ ] Verify both files render correctly on GitHub
- [ ] Confirm Claude Code picks up the new rule in future sessions