### PR TITLE
fix: address code quality findings from AI scan

### DIFF
--- a/docs/resources/dns_records.md
+++ b/docs/resources/dns_records.md
@@ -92,7 +92,7 @@ Optional:
 - `preference` (Number) Preference value for MX records (0-65535).
 - `priority` (Number) Priority for SRV records (0-65535).
 - `protocol` (String) Protocol label for SRV/TLSA records (e.g. `_tcp`).
-- `scheme` (String) Scheme for HTTPS/SVCB/TLSA records (for example `_https`, `_tcp`)
+- `scheme` (String) Scheme for HTTPS/SVCB/TLSA records (for exampel `_https`, `_tcp`)
 - `selector` (Number) Selector value for TLSA records (0-255).
 - `service` (String) Service label for SRV records (for example `_sip`).
 - `svc_params` (String) SvcParams string for HTTPS/SVCB records.

--- a/docs/resources/dns_records.md
+++ b/docs/resources/dns_records.md
@@ -92,7 +92,7 @@ Optional:
 - `preference` (Number) Preference value for MX records (0-65535).
 - `priority` (Number) Priority for SRV records (0-65535).
 - `protocol` (String) Protocol label for SRV/TLSA records (e.g. `_tcp`).
-- `scheme` (String) Scheme for HTTPS/SVCB/TLSA records (for exampel `_https`, `_tcp`)
+- `scheme` (String) Scheme for HTTPS/SVCB/TLSA records (for example `_https`, `_tcp`)
 - `selector` (Number) Selector value for TLSA records (0-255).
 - `service` (String) Service label for SRV records (for example `_sip`).
 - `svc_params` (String) SvcParams string for HTTPS/SVCB records.

--- a/internal/provider/dns_records_resource.go
+++ b/internal/provider/dns_records_resource.go
@@ -276,7 +276,7 @@ func (r *dnsRecordsResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						},
 						"scheme": schema.StringAttribute{
 							Optional:            true,
-							MarkdownDescription: "Scheme for HTTPS/SVCB/TLSA records (for exampel `_https`, `_tcp`)",
+							MarkdownDescription: "Scheme for HTTPS/SVCB/TLSA records (for example `_https`, `_tcp`)",
 							Validators: []validator.String{
 								stringvalidator.RegexMatches(schemeLabelPattern, "must start with '_' and contain alphanumeric or '-' characters"),
 							},

--- a/internal/provider/records/a_record_validator.go
+++ b/internal/provider/records/a_record_validator.go
@@ -45,8 +45,14 @@ func (v *aRecordValidator) ValidateObject(ctx context.Context, req validator.Obj
 
 	rec := &clientrecords.ARecord{}
 
-	addressAttr, _ := attrs["address"].(types.String)
-	if addressAttr.IsNull() || addressAttr.IsUnknown() {
+	addressAttr, ok := attrs["address"].(types.String)
+	if !ok {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("address"),
+			"Invalid Field Type",
+			"The 'address' field must be a string for A records.",
+		)
+	} else if addressAttr.IsNull() || addressAttr.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			req.Path.AtName("address"),
 			"Missing Required Field",

--- a/internal/provider/records/srv_record_validator.go
+++ b/internal/provider/records/srv_record_validator.go
@@ -43,8 +43,14 @@ func (v *srvRecordValidator) ValidateObject(ctx context.Context, req validator.O
 
 	rec := &clientrecords.SRVRecord{}
 
-	serviceAttr, _ := attrs["service"].(types.String)
-	if serviceAttr.IsNull() || serviceAttr.IsUnknown() {
+	serviceAttr, ok := attrs["service"].(types.String)
+	if !ok {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("service"),
+			"Invalid Field Type",
+			"The 'service' field must be a string for SRV records.",
+		)
+	} else if serviceAttr.IsNull() || serviceAttr.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			req.Path.AtName("service"),
 			"Missing Required Field",
@@ -61,8 +67,14 @@ func (v *srvRecordValidator) ValidateObject(ctx context.Context, req validator.O
 		}
 	}
 
-	protocolAttr, _ := attrs["protocol"].(types.String)
-	if protocolAttr.IsNull() || protocolAttr.IsUnknown() {
+	protocolAttr, ok := attrs["protocol"].(types.String)
+	if !ok {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("protocol"),
+			"Invalid Field Type",
+			"The 'protocol' field must be a string for SRV records.",
+		)
+	} else if protocolAttr.IsNull() || protocolAttr.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			req.Path.AtName("protocol"),
 			"Missing Required Field",
@@ -79,8 +91,14 @@ func (v *srvRecordValidator) ValidateObject(ctx context.Context, req validator.O
 		}
 	}
 
-	priorityAttr, _ := attrs["priority"].(types.Int64)
-	if priorityAttr.IsNull() || priorityAttr.IsUnknown() {
+	priorityAttr, ok := attrs["priority"].(types.Int64)
+	if !ok {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("priority"),
+			"Invalid Field Type",
+			"The 'priority' field is required for SRV records and must be an integer.",
+		)
+	} else if priorityAttr.IsNull() || priorityAttr.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			req.Path.AtName("priority"),
 			"Missing Required Field",
@@ -97,8 +115,14 @@ func (v *srvRecordValidator) ValidateObject(ctx context.Context, req validator.O
 		}
 	}
 
-	weightAttr, _ := attrs["weight"].(types.Int64)
-	if weightAttr.IsNull() || weightAttr.IsUnknown() {
+	weightAttr, ok := attrs["weight"].(types.Int64)
+	if !ok {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("weight"),
+			"Invalid Field Type",
+			"The 'weight' field must be an integer for SRV records.",
+		)
+	} else if weightAttr.IsNull() || weightAttr.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			req.Path.AtName("weight"),
 			"Missing Required Field",
@@ -115,8 +139,14 @@ func (v *srvRecordValidator) ValidateObject(ctx context.Context, req validator.O
 		}
 	}
 
-	portNumberAttr, _ := attrs["port_number"].(types.Int64)
-	if portNumberAttr.IsNull() || portNumberAttr.IsUnknown() {
+	portNumberAttr, ok := attrs["port_number"].(types.Int64)
+	if !ok {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("port_number"),
+			"Invalid Field Type",
+			"The 'port_number' field must be an integer for SRV records.",
+		)
+	} else if portNumberAttr.IsNull() || portNumberAttr.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			req.Path.AtName("port_number"),
 			"Missing Required Field",
@@ -133,8 +163,14 @@ func (v *srvRecordValidator) ValidateObject(ctx context.Context, req validator.O
 		}
 	}
 
-	targetAttr, _ := attrs["target"].(types.String)
-	if targetAttr.IsNull() || targetAttr.IsUnknown() {
+	targetAttr, ok := attrs["target"].(types.String)
+	if !ok {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("target"),
+			"Invalid Field Type",
+			"The 'target' field must be a string for SRV records.",
+		)
+	} else if targetAttr.IsNull() || targetAttr.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			req.Path.AtName("target"),
 			"Missing Required Field",


### PR DESCRIPTION
## Summary

Fixes 6 findings flagged by GitHub's AI code quality scan across 2 files:

- **docs/resources/dns_records.md**: Fix typo `exampel` → `example` in scheme attribute description
- **internal/provider/records/srv_record_validator.go**: Check type assertion `ok` value for all 6 attribute lookups (service, protocol, priority, weight, port_number, target) to prevent panics when attribute type is unexpected
- **internal/provider/records/a_record_validator.go**: Same fix for the address attribute lookup (same pattern, not flagged but equally affected)

## Test plan

- [x] `make test` — all unit tests pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build .` — builds cleanly