### PR TITLE
test: replace Test[^Acc] regex with -skip to include all unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ SHELL := /bin/bash
 
 .PHONY: test
 test:
-	go test -run 'Test[^Acc]' ./...
+	go test -skip 'TestAcc' ./...
 
 .PHONY: test-cover
 test-cover:
-	go test -run 'Test[^Acc]' -coverprofile=coverage.out -covermode=atomic ./...
+	go test -skip 'TestAcc' -coverprofile=coverage.out -covermode=atomic ./...
 	go tool cover -func=coverage.out
 
 .PHONY: testacc


### PR DESCRIPTION
Test[^Acc] is a character class excluding {A, c}, not a string negation. It silently skipped 53 unit tests including TestARecord_*, TestAAAARecord_*, and TestApplyAuth. Using -skip 'TestAcc' correctly runs all tests except acceptance tests.

