### PR TITLE
feat: add validation for mx record

### DIFF
--- a/internal/client/records/mx.go
+++ b/internal/client/records/mx.go
@@ -1,0 +1,63 @@
+package records
+
+import "fmt"
+
+// MXRecord represents an MX DNS record.
+// MX records specify the mail servers responsible for receiving email
+// for a domain. Each record pairs an exchange host with a preference —
+// lower preference values are tried first. The exchange field must be a
+// real domain name: the API returns 422 for "@" and "*" even though the
+// hostNameValue schema formally admits them, so we reject those early.
+type MXRecord struct {
+	Exchange   string
+	Preference int
+	Name       string
+	TTL        int
+}
+
+// ValidateExchange checks that the exchange is a valid domain name.
+// "@" and "*" are rejected: runtime API returns 422 for those values on
+// hostname-target fields (empirically confirmed for ALIAS, CNAME, and MX).
+func (r *MXRecord) ValidateExchange() error {
+	if r.Exchange == "@" || r.Exchange == "*" {
+		return fmt.Errorf("must be a valid domain name, got %q", r.Exchange)
+	}
+	return ValidateName(r.Exchange)
+}
+
+// ValidatePreference checks that the preference is a uint16 value (0-65535).
+// The field is stored as int so out-of-range values surface here as
+// validation errors rather than being silently truncated.
+func (r *MXRecord) ValidatePreference() error {
+	if r.Preference < 0 || r.Preference > 65535 {
+		return fmt.Errorf("must be between 0 and 65535, got %d", r.Preference)
+	}
+	return nil
+}
+
+// ValidateName checks that the record name is a valid hostname.
+func (r *MXRecord) ValidateName() error {
+	return ValidateName(r.Name)
+}
+
+// ValidateTTL checks that the TTL is within the allowed range.
+func (r *MXRecord) ValidateTTL() error {
+	return ValidateTTL(r.TTL)
+}
+
+// Validate checks all fields and returns all errors found.
+func (r *MXRecord) Validate() []error {
+	var errs []error
+	validators := []func() error{
+		r.ValidateExchange,
+		r.ValidatePreference,
+		r.ValidateName,
+		r.ValidateTTL,
+	}
+	for _, v := range validators {
+		if err := v(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}

--- a/internal/client/records/mx_test.go
+++ b/internal/client/records/mx_test.go
@@ -1,0 +1,140 @@
+package records
+
+import (
+	"strings"
+	"testing"
+)
+
+func validMXRecord() *MXRecord {
+	return &MXRecord{
+		Name:       "@",
+		Exchange:   "mail.example.com",
+		Preference: 10,
+		TTL:        3600,
+	}
+}
+
+func TestMXRecord_Validate_ValidRecord(t *testing.T) {
+	rec := validMXRecord()
+	if errs := rec.Validate(); len(errs) > 0 {
+		t.Errorf("expected no errors, got: %v", errs)
+	}
+}
+
+func TestMXRecord_Validate_BoundaryValues(t *testing.T) {
+	rec := &MXRecord{
+		Name:       "@",
+		Exchange:   "a",
+		Preference: 0,
+		TTL:        60,
+	}
+	if errs := rec.Validate(); len(errs) > 0 {
+		t.Errorf("expected no errors for boundary values, got: %v", errs)
+	}
+}
+
+func TestMXRecord_ValidateExchange(t *testing.T) {
+	tests := []struct {
+		name     string
+		exchange string
+		wantErr  bool
+	}{
+		{"valid hostname", "mail.example.com", false},
+		{"valid single char", "a", false},
+		{"valid subdomain", "sub.domain", false},
+		{"max length", strings.Repeat("a", 63) + "." + strings.Repeat("b", 63), false},
+		{"empty", "", true},
+		{"apex rejected", "@", true},
+		{"wildcard rejected", "*", true},
+		{"too long", strings.Repeat("a", 254), true},
+		{"starts with dot", ".mail.example.com", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := validMXRecord()
+			rec.Exchange = tt.exchange
+			err := rec.ValidateExchange()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateExchange(%q) error = %v, wantErr = %v", tt.exchange, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMXRecord_ValidatePreference(t *testing.T) {
+	tests := []struct {
+		name       string
+		preference int
+		wantErr    bool
+	}{
+		{"valid zero", 0, false},
+		{"valid mid", 10, false},
+		{"valid max", 65535, false},
+		{"invalid negative", -1, true},
+		{"invalid over max", 65536, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := validMXRecord()
+			rec.Preference = tt.preference
+			err := rec.ValidatePreference()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidatePreference(%d) error = %v, wantErr = %v", tt.preference, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMXRecord_ValidateName(t *testing.T) {
+	tests := []struct {
+		name    string
+		recName string
+		wantErr bool
+	}{
+		{"valid hostname", "myhost", false},
+		{"valid apex", "@", false},
+		{"valid wildcard", "*", false},
+		{"valid subdomain", "sub.domain", false},
+		{"empty", "", true},
+		{"too long", strings.Repeat("a", 254), true},
+		{"starts with dot", ".invalid", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := validMXRecord()
+			rec.Name = tt.recName
+			err := rec.ValidateName()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateName(%q) error = %v, wantErr = %v", tt.recName, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMXRecord_ValidateTTL(t *testing.T) {
+	tests := []struct {
+		name    string
+		ttl     int
+		wantErr bool
+	}{
+		{"valid", 3500, false},
+		{"min valid", 60, false},
+		{"max valid", 3600, false},
+		{"too low", 59, true},
+		{"too high", 3601, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := validMXRecord()
+			rec.TTL = tt.ttl
+			err := rec.ValidateTTL()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateTTL(%d) error = %v, wantErr = %v", tt.ttl, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/client/records/srv.go
+++ b/internal/client/records/srv.go
@@ -64,8 +64,14 @@ func (r *SRVRecord) ValidatePort() error {
 	return nil
 }
 
-// ValidateTarget checks that the target is a valid hostname between 1 and 253 characters.
+// ValidateTarget checks that the target is a valid domain name.
+// "@" and "*" are rejected: runtime API returns 422 "target is not a valid
+// domain name" for those values (empirically confirmed), even though the
+// hostNameValue schema in the API docs formally admits them.
 func (r *SRVRecord) ValidateTarget() error {
+	if r.Target == "@" || r.Target == "*" {
+		return fmt.Errorf("must be a valid domain name, got %q", r.Target)
+	}
 	if len(r.Target) < 1 || len(r.Target) > 253 {
 		return fmt.Errorf("must be between 1 and 253 characters, got %d", len(r.Target))
 	}
@@ -74,7 +80,7 @@ func (r *SRVRecord) ValidateTarget() error {
 		return fmt.Errorf("hostname pattern match failed: %w", err)
 	}
 	if !matched {
-		return fmt.Errorf("must be a valid hostname (e.g. 'server.example.com' or '@'), got %q", r.Target)
+		return fmt.Errorf("must be a valid hostname (e.g. 'server.example.com'), got %q", r.Target)
 	}
 	return nil
 }

--- a/internal/client/records/srv_test.go
+++ b/internal/client/records/srv_test.go
@@ -181,8 +181,8 @@ func TestSRVRecord_ValidateTarget(t *testing.T) {
 	}{
 		{"valid hostname", "sipserver.example.com", false},
 		{"valid single char", "a", false},
-		{"valid apex", "@", false},
-		{"valid wildcard", "*", false},
+		{"apex rejected", "@", true},
+		{"wildcard rejected", "*", true},
 		{"empty", "", true},
 		{"too long", strings.Repeat("a", 254), true},
 		{"max length", strings.Repeat("a", 63) + "." + strings.Repeat("b", 63), false},

--- a/internal/provider/cname_record_validator_acc_test.go
+++ b/internal/provider/cname_record_validator_acc_test.go
@@ -23,40 +23,85 @@ func cnameHost(suffix string) string {
 	return fmt.Sprintf("%s-cname-%s", prefix, suffix)
 }
 
-// Verifies that a standard CNAME record round-trips through create, import,
-// and destroy.
-func TestAccDNSRecords_cnameRecord(t *testing.T) {
+// Verifies that plan-time validation rejects cname values the API would
+// 422 at apply time: leading-dot hostname, apex "@", and wildcard "*".
+func TestAccDNSRecords_cnameValidation(t *testing.T) {
+	testAccPreCheck(t)
+	domain := testAccDomainValue()
+
+	cases := []struct {
+		suffix string
+		cname  string
+	}{
+		{"baddot", ".invalid"},
+		{"apex", "@"},
+		{"wildcard", "*"},
+	}
+
+	steps := make([]resource.TestStep, 0, len(cases))
+	for _, tc := range cases {
+		records := []testAccDNSRecord{
+			{
+				Type:        "CNAME",
+				Name:        cnameHost(tc.suffix),
+				TTL:         intPointer(3600),
+				StringAttrs: map[string]string{"cname": tc.cname},
+			},
+		}
+		steps = append(steps, resource.TestStep{
+			Config:      testAccDNSRecordsConfig(domain, records),
+			ExpectError: regexp.MustCompile("Invalid CName Value"),
+		})
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps:                    steps,
+	})
+}
+
+// Verifies CNAME lifecycle on a single host: create, update the target to
+// a mixed-case hostname (exercises delete+upsert), empty re-plan (verifies
+// case-insensitive cname matching), and import.
+func TestAccDNSRecords_cnameCreateAndUpdate(t *testing.T) {
 	testAccPreCheck(t)
 
 	domain := testAccDomainValue()
-	host := cnameHost("basic")
-	target := "target.example.com"
-
-	records := []testAccDNSRecord{
-		{
-			Type: "CNAME",
-			Name: host,
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"cname": target,
-			},
-		},
-	}
-
+	host := cnameHost("lifecycle")
+	initialTarget := "target.example.com"
+	updatedTarget := "Origin.Example.COM"
 	resourceName := "spaceship_dns_records.test"
-	checks := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
-		resource.TestCheckResourceAttr(resourceName, "records.0.type", "CNAME"),
-		resource.TestCheckResourceAttr(resourceName, "records.0.name", host),
-		resource.TestCheckResourceAttr(resourceName, "records.0.cname", target),
+
+	mkRecord := func(target string) []testAccDNSRecord {
+		return []testAccDNSRecord{{
+			Type:        "CNAME",
+			Name:        host,
+			TTL:         intPointer(3600),
+			StringAttrs: map[string]string{"cname": target},
+		}}
 	}
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Config: testAccDNSRecordsConfig(domain, mkRecord(initialTarget)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.type", "CNAME"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.name", host),
+					resource.TestCheckResourceAttr(resourceName, "records.0.cname", initialTarget),
+				),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, mkRecord(updatedTarget)),
+				Check:  resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, mkRecord(updatedTarget)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
 			},
 			{
 				ResourceName:            resourceName,
@@ -66,118 +111,6 @@ func TestAccDNSRecords_cnameRecord(t *testing.T) {
 			},
 		},
 		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "CNAME", host),
-	})
-}
-
-// Verifies that "@" as cname is rejected at plan time. The API treats "@" as
-// the zone-relative apex shorthand; a CNAME target must be a real hostname.
-func TestAccDNSRecords_cnameRecordApexTargetFailsPlan(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-
-	records := []testAccDNSRecord{
-		{
-			Type: "CNAME",
-			Name: cnameHost("apex"),
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"cname": "@",
-			},
-		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Invalid CName Value"),
-			},
-		},
-	})
-}
-
-// Verifies that "*" as cname is rejected at plan time. A CNAME target must
-// be a concrete hostname, not a wildcard placeholder.
-func TestAccDNSRecords_cnameRecordWildcardTargetFailsPlan(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-
-	records := []testAccDNSRecord{
-		{
-			Type: "CNAME",
-			Name: cnameHost("wild"),
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"cname": "*",
-			},
-		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Invalid CName Value"),
-			},
-		},
-	})
-}
-
-// Verifies that an invalid cname (starts with a dot) is rejected at plan time.
-func TestAccDNSRecords_cnameRecordInvalidCNameFailsPlan(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-
-	records := []testAccDNSRecord{
-		{
-			Type: "CNAME",
-			Name: cnameHost("badname"),
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"cname": ".invalid",
-			},
-		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Invalid CName Value"),
-			},
-		},
-	})
-}
-
-// Verifies that a missing cname field is rejected at plan time.
-func TestAccDNSRecords_cnameRecordMissingCNameFailsPlan(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-
-	records := []testAccDNSRecord{
-		{
-			Type: "CNAME",
-			Name: cnameHost("nocname"),
-			TTL:  intPointer(3600),
-			// no cname
-		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Missing Required Field"),
-			},
-		},
 	})
 }
 
@@ -197,7 +130,6 @@ func TestAccDNSRecords_cnameRecordImportPreExisting(t *testing.T) {
 		CName: target,
 	}
 
-	// Seed the record via the API before Terraform runs.
 	preConfig := func() {
 		testClient, err := testAccClient()
 		if err != nil {
@@ -208,7 +140,6 @@ func TestAccDNSRecords_cnameRecordImportPreExisting(t *testing.T) {
 		}
 	}
 
-	// Clean up the pre-seeded record after the test.
 	t.Cleanup(func() {
 		testClient, err := testAccClient()
 		if err != nil {
@@ -237,8 +168,6 @@ func TestAccDNSRecords_cnameRecordImportPreExisting(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				// Step 1: Apply with the pre-existing record already on
-				// the API. Terraform should adopt it without changes.
 				PreConfig: preConfig,
 				Config:    testAccDNSRecordsConfig(domain, records),
 				Check: resource.ComposeTestCheckFunc(
@@ -249,8 +178,6 @@ func TestAccDNSRecords_cnameRecordImportPreExisting(t *testing.T) {
 				),
 			},
 			{
-				// Step 2: Re-apply. Plan should be empty since state
-				// already matches configuration and API.
 				Config: testAccDNSRecordsConfig(domain, records),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -259,110 +186,10 @@ func TestAccDNSRecords_cnameRecordImportPreExisting(t *testing.T) {
 				},
 			},
 			{
-				// Step 3: Import and verify.
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"force", "records"},
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "CNAME", host),
-	})
-}
-
-// Verifies that changing the cname target of an existing record works. The
-// diff signature keys on type+name+cname, so a target change is a delete+upsert,
-// not an in-place update — this exercises both paths.
-func TestAccDNSRecords_cnameRecordUpdateTarget(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := cnameHost("update")
-
-	initialRecords := []testAccDNSRecord{
-		{
-			Type: "CNAME",
-			Name: host,
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"cname": "origin-a.example.com",
-			},
-		},
-	}
-
-	updatedRecords := []testAccDNSRecord{
-		{
-			Type: "CNAME",
-			Name: host,
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"cname": "origin-b.example.com",
-			},
-		},
-	}
-
-	resourceName := "spaceship_dns_records.test"
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, initialRecords),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.0.cname", "origin-a.example.com"),
-				),
-			},
-			{
-				// Same host, new target → old record should be deleted and new
-				// one upserted. Final state has only the new record.
-				Config: testAccDNSRecordsConfig(domain, updatedRecords),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.cname", "origin-b.example.com"),
-				),
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "CNAME", host),
-	})
-}
-
-// Verifies that cname matching is case-insensitive end-to-end: applying a
-// mixed-case cname and re-applying should produce an empty plan, regardless
-// of what casing the API persists.
-func TestAccDNSRecords_cnameRecordCaseInsensitive(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := cnameHost("case")
-
-	records := []testAccDNSRecord{
-		{
-			Type: "CNAME",
-			Name: host,
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"cname": "Origin.Example.COM",
-			},
-		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-			},
-			{
-				// If the API normalizes casing on the server and returns
-				// something different from what we sent, this will show drift
-				// and fail — surfacing a mismatch between upsert matching
-				// and read normalization.
-				Config: testAccDNSRecordsConfig(domain, records),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
 			},
 		},
 		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "CNAME", host),

--- a/internal/provider/dns_records_resource.go
+++ b/internal/provider/dns_records_resource.go
@@ -306,9 +306,6 @@ func (r *dnsRecordsResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						"preference": schema.Int64Attribute{
 							Optional:            true,
 							MarkdownDescription: "Preference value for MX records (0-65535).",
-							Validators: []validator.Int64{
-								int64validator.Between(0, 65535),
-							},
 						},
 						"nameserver": schema.StringAttribute{
 							Optional:            true,

--- a/internal/provider/dns_records_resource.go
+++ b/internal/provider/dns_records_resource.go
@@ -213,6 +213,7 @@ func (r *dnsRecordsResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						records.ALIASValidator(),
 						records.CAAValidator(),
 						records.CNAMEValidator(),
+						records.MXValidator(),
 						records.SRVValidator(),
 					},
 					Attributes: map[string]schema.Attribute{

--- a/internal/provider/https_record_validator_acc_test.go
+++ b/internal/provider/https_record_validator_acc_test.go
@@ -23,49 +23,131 @@ func httpsHost(suffix string) string {
 	return fmt.Sprintf("%s-https-%s", prefix, suffix)
 }
 
-// Verifies that a ServiceMode HTTPS record with port and scheme round-trips
-// through create, import, and destroy.
-func TestAccDNSRecords_httpsRecord(t *testing.T) {
+// Verifies plan-time rejections for HTTPS: port without scheme, non-_https
+// scheme, target_name="@" (apex), and target_name="*" (wildcard).
+func TestAccDNSRecords_httpsValidation(t *testing.T) {
+	testAccPreCheck(t)
+	domain := testAccDomainValue()
+
+	svcTarget := fmt.Sprintf("svc.%s", domain)
+
+	cases := []struct {
+		suffix      string
+		stringAttrs map[string]string
+		errRegex    string
+	}{
+		{
+			suffix: "portnoscheme",
+			stringAttrs: map[string]string{
+				"target_name": svcTarget,
+				"port":        "_443",
+			},
+			errRegex: "Invalid Scheme Value",
+		},
+		{
+			suffix: "badscheme",
+			stringAttrs: map[string]string{
+				"target_name": svcTarget,
+				"port":        "_443",
+				"scheme":      "_http",
+			},
+			errRegex: "Invalid Scheme Value",
+		},
+		{
+			suffix:      "apextarget",
+			stringAttrs: map[string]string{"target_name": "@"},
+			errRegex:    "Invalid TargetName Value",
+		},
+		{
+			suffix:      "wildtarget",
+			stringAttrs: map[string]string{"target_name": "*"},
+			errRegex:    "Invalid TargetName Value",
+		},
+	}
+
+	steps := make([]resource.TestStep, 0, len(cases))
+	for _, tc := range cases {
+		records := []testAccDNSRecord{
+			{
+				Type:        "HTTPS",
+				Name:        httpsHost(tc.suffix),
+				TTL:         intPointer(3600),
+				IntAttrs:    map[string]int{"svc_priority": 1},
+				StringAttrs: tc.stringAttrs,
+			},
+		}
+		steps = append(steps, resource.TestStep{
+			Config:      testAccDNSRecordsConfig(domain, records),
+			ExpectError: regexp.MustCompile(tc.errRegex),
+		})
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps:                    steps,
+	})
+}
+
+// Verifies HTTPS ServiceMode lifecycle: create, update target_name
+// (delete+upsert path — target is in the diff signature), update TTL (upsert
+// only — TTL is not in the signature), empty re-plan, and import.
+func TestAccDNSRecords_httpsCreateAndUpdate(t *testing.T) {
 	testAccPreCheck(t)
 
 	domain := testAccDomainValue()
-	host := httpsHost("basic")
+	host := httpsHost("lifecycle")
+	resourceName := "spaceship_dns_records.test"
 
-	records := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: host,
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
+	mkRecord := func(targetHost string, ttl int) []testAccDNSRecord {
+		return []testAccDNSRecord{{
+			Type:     "HTTPS",
+			Name:     host,
+			TTL:      intPointer(ttl),
+			IntAttrs: map[string]int{"svc_priority": 1},
 			StringAttrs: map[string]string{
-				"target_name": fmt.Sprintf("svc.%s", domain),
+				"target_name": fmt.Sprintf("%s.%s", targetHost, domain),
 				"svc_params":  "alpn=h2",
 				"port":        "_443",
 				"scheme":      "_https",
 			},
-		},
-	}
-
-	resourceName := "spaceship_dns_records.test"
-	checks := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
-		resource.TestCheckResourceAttr(resourceName, "records.0.type", "HTTPS"),
-		resource.TestCheckResourceAttr(resourceName, "records.0.name", host),
-		resource.TestCheckResourceAttr(resourceName, "records.0.svc_priority", "1"),
-		resource.TestCheckResourceAttr(resourceName, "records.0.target_name", fmt.Sprintf("svc.%s", domain)),
-		resource.TestCheckResourceAttr(resourceName, "records.0.svc_params", "alpn=h2"),
-		resource.TestCheckResourceAttr(resourceName, "records.0.port", "_443"),
-		resource.TestCheckResourceAttr(resourceName, "records.0.scheme", "_https"),
+		}}
 	}
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Config: testAccDNSRecordsConfig(domain, mkRecord("svc1", 3600)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.type", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.name", host),
+					resource.TestCheckResourceAttr(resourceName, "records.0.svc_priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.target_name", fmt.Sprintf("svc1.%s", domain)),
+					resource.TestCheckResourceAttr(resourceName, "records.0.port", "_443"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.scheme", "_https"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.ttl", "3600"),
+				),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, mkRecord("svc2", 3600)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.target_name", fmt.Sprintf("svc2.%s", domain)),
+				),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, mkRecord("svc2", 600)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.ttl", "600"),
+				),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, mkRecord("svc2", 600)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
 			},
 			{
 				ResourceName:            resourceName,
@@ -78,48 +160,63 @@ func TestAccDNSRecords_httpsRecord(t *testing.T) {
 	})
 }
 
-// Verifies an AliasMode HTTPS record (svc_priority=0, target_name=".")
-// round-trips cleanly and a re-apply produces an empty plan.
-func TestAccDNSRecords_httpsRecordAliasMode(t *testing.T) {
+// Verifies AliasMode (svc_priority=0, target_name=".") stability and the
+// transition AliasMode → ServiceMode, which is a delete+upsert because both
+// svc_priority and target_name are in the diff signature.
+func TestAccDNSRecords_httpsAliasModeLifecycle(t *testing.T) {
 	testAccPreCheck(t)
 
 	domain := testAccDomainValue()
 	host := httpsHost("alias")
-
-	records := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: host,
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 0,
-			},
-			StringAttrs: map[string]string{
-				"target_name": ".",
-			},
-		},
-	}
-
 	resourceName := "spaceship_dns_records.test"
+
+	aliasMode := []testAccDNSRecord{{
+		Type:        "HTTPS",
+		Name:        host,
+		TTL:         intPointer(3600),
+		IntAttrs:    map[string]int{"svc_priority": 0},
+		StringAttrs: map[string]string{"target_name": "."},
+	}}
+
+	serviceMode := []testAccDNSRecord{{
+		Type:     "HTTPS",
+		Name:     host,
+		TTL:      intPointer(3600),
+		IntAttrs: map[string]int{"svc_priority": 1},
+		StringAttrs: map[string]string{
+			"target_name": fmt.Sprintf("svc.%s", domain),
+			"svc_params":  "alpn=h2",
+		},
+	}}
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSRecordsConfig(domain, records),
+				Config: testAccDNSRecordsConfig(domain, aliasMode),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "records.0.svc_priority", "0"),
 					resource.TestCheckResourceAttr(resourceName, "records.0.target_name", "."),
 				),
 			},
 			{
-				// Re-apply must be a no-op — AliasMode with a dot target is
-				// a common pattern and should not drift.
-				Config: testAccDNSRecordsConfig(domain, records),
+				Config: testAccDNSRecordsConfig(domain, aliasMode),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, serviceMode),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.svc_priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.target_name", fmt.Sprintf("svc.%s", domain)),
+				),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, serviceMode),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
 				},
 			},
 		},
@@ -127,113 +224,83 @@ func TestAccDNSRecords_httpsRecordAliasMode(t *testing.T) {
 	})
 }
 
-// Verifies that missing svc_priority is rejected at plan time.
-func TestAccDNSRecords_httpsRecordMissingSvcPriorityFailsPlan(t *testing.T) {
+// Verifies six independent edge scenarios coexisting in one config: apex
+// name, boundary svc_priority=65535, wildcard port "*", high-range port
+// _64999, mixed-case svc_params (case-insensitive matching), and multiple
+// priorities on the same host.
+func TestAccDNSRecords_httpsEdgeValues(t *testing.T) {
 	testAccPreCheck(t)
 
 	domain := testAccDomainValue()
+	maxPrioHost := httpsHost("maxprio")
+	wildPortHost := httpsHost("wildport")
+	highPortHost := httpsHost("highport")
+	multiHost := httpsHost("multi")
+	resourceName := "spaceship_dns_records.test"
 
 	records := []testAccDNSRecord{
 		{
-			Type: "HTTPS",
-			Name: httpsHost("nopriority"),
-			TTL:  intPointer(3600),
+			Type:     "HTTPS",
+			Name:     "@",
+			TTL:      intPointer(3600),
+			IntAttrs: map[string]int{"svc_priority": 1},
 			StringAttrs: map[string]string{
 				"target_name": fmt.Sprintf("svc.%s", domain),
+				"svc_params":  "alpn=h2,h3",
 			},
 		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Missing Required Field"),
-			},
-		},
-	})
-}
-
-// Verifies that missing target_name is rejected at plan time.
-func TestAccDNSRecords_httpsRecordMissingTargetNameFailsPlan(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-
-	records := []testAccDNSRecord{
 		{
-			Type: "HTTPS",
-			Name: httpsHost("notarget"),
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
-		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Missing Required Field"),
-			},
-		},
-	})
-}
-
-// Verifies that setting port without scheme is rejected at plan time —
-// HTTPS records require scheme="_https" whenever port is specified.
-func TestAccDNSRecords_httpsRecordPortWithoutSchemeFailsPlan(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-
-	records := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: httpsHost("noscheme"),
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
+			Type:     "HTTPS",
+			Name:     maxPrioHost,
+			TTL:      intPointer(3600),
+			IntAttrs: map[string]int{"svc_priority": 65535},
 			StringAttrs: map[string]string{
 				"target_name": fmt.Sprintf("svc.%s", domain),
-				"port":        "_443",
+				"svc_params":  "ALPN=H2", // mixed-case, verifies case-insensitive matching on re-plan
 			},
 		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Invalid Scheme Value"),
-			},
-		},
-	})
-}
-
-// Verifies that a non-'_https' scheme is rejected at plan time.
-func TestAccDNSRecords_httpsRecordInvalidSchemeFailsPlan(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-
-	records := []testAccDNSRecord{
 		{
-			Type: "HTTPS",
-			Name: httpsHost("badscheme"),
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
+			Type:     "HTTPS",
+			Name:     wildPortHost,
+			TTL:      intPointer(3600),
+			IntAttrs: map[string]int{"svc_priority": 1},
 			StringAttrs: map[string]string{
 				"target_name": fmt.Sprintf("svc.%s", domain),
-				"port":        "_443",
-				"scheme":      "_http",
+				"svc_params":  "alpn=h2",
+				"port":        "*",
+				"scheme":      "_https",
+			},
+		},
+		{
+			Type:     "HTTPS",
+			Name:     highPortHost,
+			TTL:      intPointer(3600),
+			IntAttrs: map[string]int{"svc_priority": 1},
+			StringAttrs: map[string]string{
+				"target_name": fmt.Sprintf("svc.%s", domain),
+				"svc_params":  "alpn=h2",
+				"port":        "_64999",
+				"scheme":      "_https",
+			},
+		},
+		{
+			Type:     "HTTPS",
+			Name:     multiHost,
+			TTL:      intPointer(3600),
+			IntAttrs: map[string]int{"svc_priority": 1},
+			StringAttrs: map[string]string{
+				"target_name": fmt.Sprintf("svc1.%s", domain),
+				"svc_params":  "alpn=h2",
+			},
+		},
+		{
+			Type:     "HTTPS",
+			Name:     multiHost,
+			TTL:      intPointer(3600),
+			IntAttrs: map[string]int{"svc_priority": 2},
+			StringAttrs: map[string]string{
+				"target_name": fmt.Sprintf("svc2.%s", domain),
+				"svc_params":  "alpn=h3",
 			},
 		},
 	}
@@ -242,42 +309,89 @@ func TestAccDNSRecords_httpsRecordInvalidSchemeFailsPlan(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Invalid Scheme Value"),
+				Config: testAccDNSRecordsConfig(domain, records),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.#", "6"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.name", "@"),
+					resource.TestCheckResourceAttr(resourceName, "records.1.svc_priority", "65535"),
+					resource.TestCheckResourceAttr(resourceName, "records.2.port", "*"),
+					resource.TestCheckResourceAttr(resourceName, "records.3.port", "_64999"),
+				),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, records),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
 			},
 		},
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckDNSRecordAbsent(domain, "HTTPS", "@"),
+			testAccCheckDNSRecordAbsent(domain, "HTTPS", maxPrioHost),
+			testAccCheckDNSRecordAbsent(domain, "HTTPS", wildPortHost),
+			testAccCheckDNSRecordAbsent(domain, "HTTPS", highPortHost),
+			testAccCheckDNSRecordAbsent(domain, "HTTPS", multiHost),
+		),
 	})
 }
 
-// Verifies that target_name="@" is rejected at plan time — the API requires
-// an FQDN or the literal ".", not the apex placeholder.
-func TestAccDNSRecords_httpsRecordInvalidTargetNameFailsPlan(t *testing.T) {
+// Verifies HTTPS coexists with an A record on the same host (type is part
+// of recordKey so same-name cross-type records must not collide), and that
+// removing HTTPS from config while keeping A exercises the Update delete
+// path distinct from resource destroy.
+func TestAccDNSRecords_httpsRecordComposition(t *testing.T) {
 	testAccPreCheck(t)
 
 	domain := testAccDomainValue()
+	host := httpsHost("compose")
+	resourceName := "spaceship_dns_records.test"
 
-	records := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: httpsHost("badtarget"),
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
-			StringAttrs: map[string]string{
-				"target_name": "@",
-			},
+	httpsRecord := testAccDNSRecord{
+		Type:     "HTTPS",
+		Name:     host,
+		TTL:      intPointer(3600),
+		IntAttrs: map[string]int{"svc_priority": 1},
+		StringAttrs: map[string]string{
+			"target_name": fmt.Sprintf("svc.%s", domain),
+			"svc_params":  "alpn=h2",
 		},
 	}
+	aRecord := testAccDNSRecord{
+		Type:        "A",
+		Name:        host,
+		TTL:         intPointer(3600),
+		StringAttrs: map[string]string{"address": "1.2.3.4"},
+	}
+
+	withBoth := []testAccDNSRecord{httpsRecord, aRecord}
+	onlyA := []testAccDNSRecord{aRecord}
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Invalid TargetName Value"),
+				Config: testAccDNSRecordsConfig(domain, withBoth),
+				Check:  resource.TestCheckResourceAttr(resourceName, "records.#", "2"),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, withBoth),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, onlyA),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.type", "A"),
+					testAccCheckDNSRecordAbsent(domain, "HTTPS", host),
+				),
 			},
 		},
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckDNSRecordAbsent(domain, "HTTPS", host),
+			testAccCheckDNSRecordAbsent(domain, "A", host),
+		),
 	})
 }
 
@@ -299,7 +413,6 @@ func TestAccDNSRecords_httpsRecordImportPreExisting(t *testing.T) {
 		SvcParams:   "alpn=h2",
 	}
 
-	// Seed the record via the API before Terraform runs.
 	preConfig := func() {
 		testClient, err := testAccClient()
 		if err != nil {
@@ -310,7 +423,6 @@ func TestAccDNSRecords_httpsRecordImportPreExisting(t *testing.T) {
 		}
 	}
 
-	// Clean up the pre-seeded record after the test.
 	t.Cleanup(func() {
 		testClient, err := testAccClient()
 		if err != nil {
@@ -343,8 +455,6 @@ func TestAccDNSRecords_httpsRecordImportPreExisting(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				// Step 1: Apply with the pre-existing record already on the
-				// API. Terraform should adopt it without changes.
 				PreConfig: preConfig,
 				Config:    testAccDNSRecordsConfig(domain, records),
 				Check: resource.ComposeTestCheckFunc(
@@ -357,8 +467,6 @@ func TestAccDNSRecords_httpsRecordImportPreExisting(t *testing.T) {
 				),
 			},
 			{
-				// Step 2: Re-apply. Plan should be empty since state already
-				// matches configuration and API.
 				Config: testAccDNSRecordsConfig(domain, records),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -367,7 +475,6 @@ func TestAccDNSRecords_httpsRecordImportPreExisting(t *testing.T) {
 				},
 			},
 			{
-				// Step 3: Import and verify.
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -375,656 +482,5 @@ func TestAccDNSRecords_httpsRecordImportPreExisting(t *testing.T) {
 			},
 		},
 		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "HTTPS", host),
-	})
-}
-
-// Verifies that changing target_name works. The diff signature keys HTTPS
-// on svc_priority+target_name+svc_params+port+scheme, so a target change
-// is a delete+upsert, not an in-place update.
-func TestAccDNSRecords_httpsRecordUpdateTargetName(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := httpsHost("update")
-
-	initialRecords := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: host,
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
-			StringAttrs: map[string]string{
-				"target_name": fmt.Sprintf("svc1.%s", domain),
-				"svc_params":  "alpn=h2",
-			},
-		},
-	}
-
-	updatedRecords := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: host,
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
-			StringAttrs: map[string]string{
-				"target_name": fmt.Sprintf("svc2.%s", domain),
-				"svc_params":  "alpn=h2",
-			},
-		},
-	}
-
-	resourceName := "spaceship_dns_records.test"
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, initialRecords),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.0.target_name", fmt.Sprintf("svc1.%s", domain)),
-				),
-			},
-			{
-				// Same host, new target → old record should be deleted and
-				// new one upserted. Final state has only the new record.
-				Config: testAccDNSRecordsConfig(domain, updatedRecords),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.target_name", fmt.Sprintf("svc2.%s", domain)),
-				),
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "HTTPS", host),
-	})
-}
-
-// Verifies that svc_params matching is case-insensitive end-to-end: a
-// mixed-case value should re-apply to an empty plan, regardless of how the
-// API persists the casing.
-func TestAccDNSRecords_httpsRecordSvcParamsCaseInsensitive(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := httpsHost("case")
-
-	records := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: host,
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
-			StringAttrs: map[string]string{
-				"target_name": fmt.Sprintf("svc.%s", domain),
-				"svc_params":  "ALPN=H2",
-			},
-		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-			},
-			{
-				// If the API normalizes casing server-side and returns
-				// something different, this will surface as drift.
-				Config: testAccDNSRecordsConfig(domain, records),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "HTTPS", host),
-	})
-}
-
-// Verifies that two HTTPS records on the same host with different
-// svc_priority values coexist. Real-world HTTPS config often pairs a
-// priority-0 AliasMode record with higher-priority ServiceMode alternatives.
-func TestAccDNSRecords_httpsRecordMultiplePrioritiesSameHost(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := httpsHost("multi")
-
-	records := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: host,
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
-			StringAttrs: map[string]string{
-				"target_name": fmt.Sprintf("svc1.%s", domain),
-				"svc_params":  "alpn=h2",
-			},
-		},
-		{
-			Type: "HTTPS",
-			Name: host,
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 2,
-			},
-			StringAttrs: map[string]string{
-				"target_name": fmt.Sprintf("svc2.%s", domain),
-				"svc_params":  "alpn=h3",
-			},
-		},
-	}
-
-	resourceName := "spaceship_dns_records.test"
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.#", "2"),
-				),
-			},
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "HTTPS", host),
-	})
-}
-
-// Verifies that svc_priority=65535 (uint16 max) round-trips without being
-// silently coerced to a lower value.
-func TestAccDNSRecords_httpsRecordBoundarySvcPriority(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := httpsHost("maxprio")
-
-	records := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: host,
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 65535,
-			},
-			StringAttrs: map[string]string{
-				"target_name": fmt.Sprintf("svc.%s", domain),
-				"svc_params":  "alpn=h2",
-			},
-		},
-	}
-
-	resourceName := "spaceship_dns_records.test"
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.0.svc_priority", "65535"),
-				),
-			},
-			{
-				// Re-apply with max priority must be a no-op.
-				Config: testAccDNSRecordsConfig(domain, records),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "HTTPS", host),
-	})
-}
-
-// Verifies that port="*" (the wildcard port form) is accepted by the API
-// and round-trips. The client spec lists "*" as a valid alternative to the
-// "_NNNN" underscored port form.
-func TestAccDNSRecords_httpsRecordWildcardPort(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := httpsHost("wildport")
-
-	records := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: host,
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
-			StringAttrs: map[string]string{
-				"target_name": fmt.Sprintf("svc.%s", domain),
-				"svc_params":  "alpn=h2",
-				"port":        "*",
-				"scheme":      "_https",
-			},
-		},
-	}
-
-	resourceName := "spaceship_dns_records.test"
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.0.port", "*"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.scheme", "_https"),
-				),
-			},
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "HTTPS", host),
-	})
-}
-
-// Verifies that an HTTPS record at the zone apex (name="@") round-trips.
-// Apex HTTPS records are common in modern deployments (ECH, HTTP/3 hints).
-func TestAccDNSRecords_httpsRecordApexName(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-
-	records := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: "@",
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
-			StringAttrs: map[string]string{
-				"target_name": fmt.Sprintf("svc.%s", domain),
-				"svc_params":  "alpn=h2,h3",
-			},
-		},
-	}
-
-	resourceName := "spaceship_dns_records.test"
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.0.name", "@"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.svc_params", "alpn=h2,h3"),
-				),
-			},
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "HTTPS", "@"),
-	})
-}
-
-// Verifies transition from AliasMode (priority=0, target=".") to ServiceMode
-// (priority=1, real FQDN). Since both svc_priority and target_name are in the
-// diff signature, this forces a delete+upsert, not an in-place update.
-func TestAccDNSRecords_httpsRecordAliasToServiceModeUpdate(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := httpsHost("modexchg")
-
-	aliasMode := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: host,
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 0,
-			},
-			StringAttrs: map[string]string{
-				"target_name": ".",
-			},
-		},
-	}
-
-	serviceMode := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: host,
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
-			StringAttrs: map[string]string{
-				"target_name": fmt.Sprintf("svc.%s", domain),
-				"svc_params":  "alpn=h2",
-			},
-		},
-	}
-
-	resourceName := "spaceship_dns_records.test"
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, aliasMode),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.0.svc_priority", "0"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.target_name", "."),
-				),
-			},
-			{
-				// AliasMode → ServiceMode: old record deleted, new one upserted.
-				Config: testAccDNSRecordsConfig(domain, serviceMode),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.svc_priority", "1"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.target_name", fmt.Sprintf("svc.%s", domain)),
-				),
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "HTTPS", host),
-	})
-}
-
-// Verifies that changing only the TTL triggers an upsert without changing
-// record identity. recordValueSignature excludes TTL, so the diff skip-check
-// (signature match AND TTL match) must catch TTL-only differences.
-func TestAccDNSRecords_httpsRecordTTLUpdate(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := httpsHost("ttl")
-
-	base := testAccDNSRecord{
-		Type: "HTTPS",
-		Name: host,
-		IntAttrs: map[string]int{
-			"svc_priority": 1,
-		},
-		StringAttrs: map[string]string{
-			"target_name": fmt.Sprintf("svc.%s", domain),
-			"svc_params":  "alpn=h2",
-		},
-	}
-	initial := base
-	initial.TTL = intPointer(3600)
-	updated := base
-	updated.TTL = intPointer(600)
-
-	resourceName := "spaceship_dns_records.test"
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, []testAccDNSRecord{initial}),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.0.ttl", "3600"),
-				),
-			},
-			{
-				// Same identity fields, only TTL differs → record is upserted
-				// but count stays at 1. Re-applying must converge to empty.
-				Config: testAccDNSRecordsConfig(domain, []testAccDNSRecord{updated}),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.ttl", "600"),
-				),
-			},
-			{
-				Config: testAccDNSRecordsConfig(domain, []testAccDNSRecord{updated}),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "HTTPS", host),
-	})
-}
-
-// Verifies that an HTTPS record and an A record on the same host coexist.
-// recordKey includes the record type, so same-name records of different
-// types must not conflict in the diff logic.
-func TestAccDNSRecords_httpsRecordCoexistsWithA(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := httpsHost("coexist")
-
-	records := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: host,
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
-			StringAttrs: map[string]string{
-				"target_name": fmt.Sprintf("svc.%s", domain),
-				"svc_params":  "alpn=h2",
-			},
-		},
-		{
-			Type: "A",
-			Name: host,
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"address": "1.2.3.4",
-			},
-		},
-	}
-
-	resourceName := "spaceship_dns_records.test"
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.#", "2"),
-				),
-			},
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-		},
-		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckDNSRecordAbsent(domain, "HTTPS", host),
-			testAccCheckDNSRecordAbsent(domain, "A", host),
-		),
-	})
-}
-
-// Verifies that removing an HTTPS record from the config (while leaving the
-// resource in place) deletes it from the API. Exercises the Update delete
-// path, which is distinct from resource destroy.
-func TestAccDNSRecords_httpsRecordRemovedFromConfig(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	httpsName := httpsHost("removed")
-	aName := httpsHost("kept")
-
-	withHTTPS := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: httpsName,
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
-			StringAttrs: map[string]string{
-				"target_name": fmt.Sprintf("svc.%s", domain),
-				"svc_params":  "alpn=h2",
-			},
-		},
-		{
-			Type: "A",
-			Name: aName,
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"address": "1.2.3.4",
-			},
-		},
-	}
-
-	withoutHTTPS := []testAccDNSRecord{
-		{
-			Type: "A",
-			Name: aName,
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"address": "1.2.3.4",
-			},
-		},
-	}
-
-	resourceName := "spaceship_dns_records.test"
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, withHTTPS),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.#", "2"),
-				),
-			},
-			{
-				// Remove HTTPS from config. The A record stays; HTTPS should
-				// be deleted from the API.
-				Config: testAccDNSRecordsConfig(domain, withoutHTTPS),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.type", "A"),
-					testAccCheckDNSRecordAbsent(domain, "HTTPS", httpsName),
-				),
-			},
-		},
-		CheckDestroy: resource.ComposeTestCheckFunc(
-			testAccCheckDNSRecordAbsent(domain, "HTTPS", httpsName),
-			testAccCheckDNSRecordAbsent(domain, "A", aName),
-		),
-	})
-}
-
-// Verifies that a port in the 60000-65535 range round-trips. The API spec's
-// underscoredPort regex rejects many valid ports in this range (e.g.
-// _64999); this pins down that 1-65535 is actually accepted end-to-end.
-func TestAccDNSRecords_httpsRecordPortInHighRange(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := httpsHost("highport")
-
-	records := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: host,
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
-			StringAttrs: map[string]string{
-				"target_name": fmt.Sprintf("svc.%s", domain),
-				"svc_params":  "alpn=h2",
-				"port":        "_64999",
-				"scheme":      "_https",
-			},
-		},
-	}
-
-	resourceName := "spaceship_dns_records.test"
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.0.port", "_64999"),
-				),
-			},
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "HTTPS", host),
-	})
-}
-
-// Verifies that target_name="*" is rejected at plan time. Mirrors the
-// target_name="@" case but exercises the wildcard branch of the reject list.
-func TestAccDNSRecords_httpsRecordWildcardTargetFailsPlan(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-
-	records := []testAccDNSRecord{
-		{
-			Type: "HTTPS",
-			Name: httpsHost("wildtarget"),
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"svc_priority": 1,
-			},
-			StringAttrs: map[string]string{
-				"target_name": "*",
-			},
-		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Invalid TargetName Value"),
-			},
-		},
 	})
 }

--- a/internal/provider/mx_record_validator_acc_test.go
+++ b/internal/provider/mx_record_validator_acc_test.go
@@ -23,44 +23,91 @@ func mxHost(suffix string) string {
 	return fmt.Sprintf("%s-mx-%s", prefix, suffix)
 }
 
-// Verifies that a standard MX record round-trips through create, import,
-// and destroy.
-func TestAccDNSRecords_mxRecord(t *testing.T) {
+// Verifies that plan-time validation rejects exchange values the API would
+// 422 at apply time: leading-dot hostname, apex "@", and wildcard "*".
+func TestAccDNSRecords_mxValidation(t *testing.T) {
+	testAccPreCheck(t)
+	domain := testAccDomainValue()
+
+	cases := []struct {
+		suffix   string
+		exchange string
+	}{
+		{"baddot", ".mail." + domain},
+		{"apex", "@"},
+		{"wildcard", "*"},
+	}
+
+	steps := make([]resource.TestStep, 0, len(cases))
+	for _, tc := range cases {
+		records := []testAccDNSRecord{
+			{
+				Type:        "MX",
+				Name:        mxHost(tc.suffix),
+				TTL:         intPointer(3600),
+				StringAttrs: map[string]string{"exchange": tc.exchange},
+				IntAttrs:    map[string]int{"preference": 10},
+			},
+		}
+		steps = append(steps, resource.TestStep{
+			Config:      testAccDNSRecordsConfig(domain, records),
+			ExpectError: regexp.MustCompile("Invalid Exchange Value"),
+		})
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps:                    steps,
+	})
+}
+
+// Verifies MX lifecycle on a single host: create, update preference
+// (delete+upsert path), update TTL, empty re-plan, and import.
+func TestAccDNSRecords_mxCreateAndUpdate(t *testing.T) {
 	testAccPreCheck(t)
 
 	domain := testAccDomainValue()
-	host := mxHost("basic")
+	host := mxHost("lifecycle")
 	exchange := fmt.Sprintf("mail.%s", domain)
-
-	records := []testAccDNSRecord{
-		{
-			Type: "MX",
-			Name: host,
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"exchange": exchange,
-			},
-			IntAttrs: map[string]int{
-				"preference": 10,
-			},
-		},
-	}
-
 	resourceName := "spaceship_dns_records.test"
-	checks := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
-		resource.TestCheckResourceAttr(resourceName, "records.0.type", "MX"),
-		resource.TestCheckResourceAttr(resourceName, "records.0.name", host),
-		resource.TestCheckResourceAttr(resourceName, "records.0.exchange", exchange),
-		resource.TestCheckResourceAttr(resourceName, "records.0.preference", "10"),
+
+	mkRecord := func(ttl, pref int) []testAccDNSRecord {
+		return []testAccDNSRecord{{
+			Type:        "MX",
+			Name:        host,
+			TTL:         intPointer(ttl),
+			StringAttrs: map[string]string{"exchange": exchange},
+			IntAttrs:    map[string]int{"preference": pref},
+		}}
 	}
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Config: testAccDNSRecordsConfig(domain, mkRecord(3600, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.type", "MX"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.name", host),
+					resource.TestCheckResourceAttr(resourceName, "records.0.exchange", exchange),
+					resource.TestCheckResourceAttr(resourceName, "records.0.preference", "10"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.ttl", "3600"),
+				),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, mkRecord(3600, 20)),
+				Check:  resource.TestCheckResourceAttr(resourceName, "records.0.preference", "20"),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, mkRecord(300, 20)),
+				Check:  resource.TestCheckResourceAttr(resourceName, "records.0.ttl", "300"),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, mkRecord(300, 20)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
 			},
 			{
 				ResourceName:            resourceName,
@@ -73,20 +120,46 @@ func TestAccDNSRecords_mxRecord(t *testing.T) {
 	})
 }
 
-// Verifies that a missing exchange field is rejected at plan time.
-func TestAccDNSRecords_mxRecordMissingExchangeFailsPlan(t *testing.T) {
+// Verifies three edge scenarios coexisting in one config: preference=0
+// round-trips, mixed-case exchange converges (case-insensitive matching),
+// and multiple MX records on the same host with different exchanges.
+func TestAccDNSRecords_mxEdgeValues(t *testing.T) {
 	testAccPreCheck(t)
 
 	domain := testAccDomainValue()
+	zeroHost := mxHost("zero")
+	caseHost := mxHost("case")
+	multiHost := mxHost("multi")
+	resourceName := "spaceship_dns_records.test"
 
 	records := []testAccDNSRecord{
 		{
-			Type: "MX",
-			Name: mxHost("noexchange"),
-			TTL:  intPointer(3600),
-			IntAttrs: map[string]int{
-				"preference": 10,
-			},
+			Type:        "MX",
+			Name:        zeroHost,
+			TTL:         intPointer(3600),
+			StringAttrs: map[string]string{"exchange": fmt.Sprintf("mail.%s", domain)},
+			IntAttrs:    map[string]int{"preference": 0},
+		},
+		{
+			Type:        "MX",
+			Name:        caseHost,
+			TTL:         intPointer(3600),
+			StringAttrs: map[string]string{"exchange": fmt.Sprintf("Mail.%s", domain)},
+			IntAttrs:    map[string]int{"preference": 10},
+		},
+		{
+			Type:        "MX",
+			Name:        multiHost,
+			TTL:         intPointer(3600),
+			StringAttrs: map[string]string{"exchange": fmt.Sprintf("mail1.%s", domain)},
+			IntAttrs:    map[string]int{"preference": 10},
+		},
+		{
+			Type:        "MX",
+			Name:        multiHost,
+			TTL:         intPointer(3600),
+			StringAttrs: map[string]string{"exchange": fmt.Sprintf("mail2.%s", domain)},
+			IntAttrs:    map[string]int{"preference": 20},
 		},
 	}
 
@@ -94,103 +167,24 @@ func TestAccDNSRecords_mxRecordMissingExchangeFailsPlan(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Missing Required Field"),
+				Config: testAccDNSRecordsConfig(domain, records),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.preference", "0"),
+				),
 			},
-		},
-	})
-}
-
-// Verifies that a missing preference field is rejected at plan time.
-func TestAccDNSRecords_mxRecordMissingPreferenceFailsPlan(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-
-	records := []testAccDNSRecord{
-		{
-			Type: "MX",
-			Name: mxHost("nopref"),
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"exchange": fmt.Sprintf("mail.%s", testAccDomainValue()),
-			},
-		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
 			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Missing Required Field"),
+				Config: testAccDNSRecordsConfig(domain, records),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
 			},
 		},
-	})
-}
-
-// Verifies that an invalid exchange (starts with dot) is rejected at plan time
-// by the client-layer ValidateExchange check.
-func TestAccDNSRecords_mxRecordInvalidExchangeFailsPlan(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-
-	records := []testAccDNSRecord{
-		{
-			Type: "MX",
-			Name: mxHost("badexchange"),
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"exchange": ".mail.example.com",
-			},
-			IntAttrs: map[string]int{
-				"preference": 10,
-			},
-		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Invalid Exchange Value"),
-			},
-		},
-	})
-}
-
-// Verifies that a preference above uint16 range is rejected at plan time.
-// The schema-level int64validator.Between(0, 65535) catches this before the
-// Object validator runs, so the error shape differs from other fields.
-func TestAccDNSRecords_mxRecordInvalidPreferenceFailsPlan(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-
-	records := []testAccDNSRecord{
-		{
-			Type: "MX",
-			Name: mxHost("badpref"),
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"exchange": fmt.Sprintf("mail.%s", testAccDomainValue()),
-			},
-			IntAttrs: map[string]int{
-				"preference": 70000,
-			},
-		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Invalid Attribute Value"),
-			},
-		},
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckDNSRecordAbsent(domain, "MX", zeroHost),
+			testAccCheckDNSRecordAbsent(domain, "MX", caseHost),
+			testAccCheckDNSRecordAbsent(domain, "MX", multiHost),
+		),
 	})
 }
 
@@ -276,364 +270,6 @@ func TestAccDNSRecords_mxRecordImportPreExisting(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"force", "records"},
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "MX", host),
-	})
-}
-
-// Verifies that changing preference on an existing MX record converges. The
-// diff signature keys on exchange+preference, so a preference change is a
-// delete+upsert rather than an in-place update — this exercises both paths.
-func TestAccDNSRecords_mxRecordUpdatePreference(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := mxHost("update")
-	exchange := fmt.Sprintf("mail.%s", domain)
-
-	initialRecords := []testAccDNSRecord{
-		{
-			Type: "MX",
-			Name: host,
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"exchange": exchange,
-			},
-			IntAttrs: map[string]int{
-				"preference": 10,
-			},
-		},
-	}
-
-	updatedRecords := []testAccDNSRecord{
-		{
-			Type: "MX",
-			Name: host,
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"exchange": exchange,
-			},
-			IntAttrs: map[string]int{
-				"preference": 20,
-			},
-		},
-	}
-
-	resourceName := "spaceship_dns_records.test"
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, initialRecords),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.0.preference", "10"),
-				),
-			},
-			{
-				Config: testAccDNSRecordsConfig(domain, updatedRecords),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.preference", "20"),
-				),
-			},
-			{
-				Config: testAccDNSRecordsConfig(domain, updatedRecords),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "MX", host),
-	})
-}
-
-// Verifies that two MX records on the same host with different exchanges
-// coexist. Real-world MX config typically pairs a primary and secondary
-// mail server on the zone apex with different preferences.
-func TestAccDNSRecords_mxRecordMultipleExchangesSameHost(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := mxHost("multi")
-	primary := fmt.Sprintf("mail1.%s", domain)
-	secondary := fmt.Sprintf("mail2.%s", domain)
-
-	records := []testAccDNSRecord{
-		{
-			Type: "MX",
-			Name: host,
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"exchange": primary,
-			},
-			IntAttrs: map[string]int{
-				"preference": 10,
-			},
-		},
-		{
-			Type: "MX",
-			Name: host,
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"exchange": secondary,
-			},
-			IntAttrs: map[string]int{
-				"preference": 20,
-			},
-		},
-	}
-
-	resourceName := "spaceship_dns_records.test"
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.#", "2"),
-				),
-			},
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "MX", host),
-	})
-}
-
-// Verifies that exchange matching is case-insensitive end-to-end: applying a
-// mixed-case exchange and re-applying produces an empty plan regardless of
-// what casing the API persists.
-func TestAccDNSRecords_mxRecordExchangeCaseInsensitive(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := mxHost("case")
-
-	records := []testAccDNSRecord{
-		{
-			Type: "MX",
-			Name: host,
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"exchange": fmt.Sprintf("Mail.%s", domain),
-			},
-			IntAttrs: map[string]int{
-				"preference": 10,
-			},
-		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-			},
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "MX", host),
-	})
-}
-
-// Verifies that exchange="@" is rejected at plan time. The API returns 422
-// for this value at apply time (empirically confirmed), so the client-layer
-// validator short-circuits with a plan-time error to avoid a failed apply.
-func TestAccDNSRecords_mxRecordApexExchangeFailsPlan(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-
-	records := []testAccDNSRecord{
-		{
-			Type: "MX",
-			Name: mxHost("apexexch"),
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"exchange": "@",
-			},
-			IntAttrs: map[string]int{
-				"preference": 10,
-			},
-		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Invalid Exchange Value"),
-			},
-		},
-	})
-}
-
-// Verifies that exchange="*" is rejected at plan time. Same rationale as
-// the apex test: API returns 422 at apply time, so plan-time rejection is
-// the correct UX.
-func TestAccDNSRecords_mxRecordWildcardExchangeFailsPlan(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-
-	records := []testAccDNSRecord{
-		{
-			Type: "MX",
-			Name: mxHost("wildexch"),
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"exchange": "*",
-			},
-			IntAttrs: map[string]int{
-				"preference": 10,
-			},
-		},
-	}
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccDNSRecordsConfig(domain, records),
-				ExpectError: regexp.MustCompile("Invalid Exchange Value"),
-			},
-		},
-	})
-}
-
-// Verifies that TTL is actually updatable on an MX record. The API docs
-// omit ttl from MxResourceRecord, but the UI console sets it — this test
-// confirms empirically whether per-record TTL is honored. Creates with
-// TTL=3600, updates to TTL=300, checks state reflects 300, then re-applies
-// the same config with ExpectEmptyPlan to catch any server-side normalization.
-//
-// If this test fails with drift on the final step, the API is silently
-// coercing MX TTL to a default and per-record TTL is effectively read-only.
-func TestAccDNSRecords_mxRecordUpdateTTL(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := mxHost("ttlupdate")
-	exchange := fmt.Sprintf("mail.%s", domain)
-
-	initialRecords := []testAccDNSRecord{
-		{
-			Type: "MX",
-			Name: host,
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"exchange": exchange,
-			},
-			IntAttrs: map[string]int{
-				"preference": 10,
-			},
-		},
-	}
-
-	updatedRecords := []testAccDNSRecord{
-		{
-			Type: "MX",
-			Name: host,
-			TTL:  intPointer(300),
-			StringAttrs: map[string]string{
-				"exchange": exchange,
-			},
-			IntAttrs: map[string]int{
-				"preference": 10,
-			},
-		},
-	}
-
-	resourceName := "spaceship_dns_records.test"
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, initialRecords),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.0.ttl", "3600"),
-				),
-			},
-			{
-				Config: testAccDNSRecordsConfig(domain, updatedRecords),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "records.0.ttl", "300"),
-				),
-			},
-			{
-				Config: testAccDNSRecordsConfig(domain, updatedRecords),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-		},
-		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "MX", host),
-	})
-}
-
-// Verifies that preference=0 (highest priority per RFC 5321) round-trips
-// without being silently coerced or treated as a missing value.
-func TestAccDNSRecords_mxRecordZeroPreference(t *testing.T) {
-	testAccPreCheck(t)
-
-	domain := testAccDomainValue()
-	host := mxHost("zeropref")
-	exchange := fmt.Sprintf("mail.%s", domain)
-
-	records := []testAccDNSRecord{
-		{
-			Type: "MX",
-			Name: host,
-			TTL:  intPointer(3600),
-			StringAttrs: map[string]string{
-				"exchange": exchange,
-			},
-			IntAttrs: map[string]int{
-				"preference": 0,
-			},
-		},
-	}
-
-	resourceName := "spaceship_dns_records.test"
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "records.0.preference", "0"),
-				),
-			},
-			{
-				Config: testAccDNSRecordsConfig(domain, records),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
 			},
 		},
 		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "MX", host),

--- a/internal/provider/mx_record_validator_acc_test.go
+++ b/internal/provider/mx_record_validator_acc_test.go
@@ -1,0 +1,641 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"terraform-provider-spaceship/internal/client"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+// mxHost returns a unique record name per test so parallel/repeat runs
+// against the same SPACESHIP_TEST_DOMAIN don't collide.
+func mxHost(suffix string) string {
+	prefix := os.Getenv("SPACESHIP_TEST_RECORD_PREFIX")
+	if prefix == "" {
+		prefix = "tfacc"
+	}
+	return fmt.Sprintf("%s-mx-%s", prefix, suffix)
+}
+
+// Verifies that a standard MX record round-trips through create, import,
+// and destroy.
+func TestAccDNSRecords_mxRecord(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+	host := mxHost("basic")
+	exchange := fmt.Sprintf("mail.%s", domain)
+
+	records := []testAccDNSRecord{
+		{
+			Type: "MX",
+			Name: host,
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"exchange": exchange,
+			},
+			IntAttrs: map[string]int{
+				"preference": 10,
+			},
+		},
+	}
+
+	resourceName := "spaceship_dns_records.test"
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, "records.0.type", "MX"),
+		resource.TestCheckResourceAttr(resourceName, "records.0.name", host),
+		resource.TestCheckResourceAttr(resourceName, "records.0.exchange", exchange),
+		resource.TestCheckResourceAttr(resourceName, "records.0.preference", "10"),
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSRecordsConfig(domain, records),
+				Check:  resource.ComposeTestCheckFunc(checks...),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force", "records"},
+			},
+		},
+		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "MX", host),
+	})
+}
+
+// Verifies that a missing exchange field is rejected at plan time.
+func TestAccDNSRecords_mxRecordMissingExchangeFailsPlan(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+
+	records := []testAccDNSRecord{
+		{
+			Type: "MX",
+			Name: mxHost("noexchange"),
+			TTL:  intPointer(3600),
+			IntAttrs: map[string]int{
+				"preference": 10,
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDNSRecordsConfig(domain, records),
+				ExpectError: regexp.MustCompile("Missing Required Field"),
+			},
+		},
+	})
+}
+
+// Verifies that a missing preference field is rejected at plan time.
+func TestAccDNSRecords_mxRecordMissingPreferenceFailsPlan(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+
+	records := []testAccDNSRecord{
+		{
+			Type: "MX",
+			Name: mxHost("nopref"),
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"exchange": fmt.Sprintf("mail.%s", testAccDomainValue()),
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDNSRecordsConfig(domain, records),
+				ExpectError: regexp.MustCompile("Missing Required Field"),
+			},
+		},
+	})
+}
+
+// Verifies that an invalid exchange (starts with dot) is rejected at plan time
+// by the client-layer ValidateExchange check.
+func TestAccDNSRecords_mxRecordInvalidExchangeFailsPlan(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+
+	records := []testAccDNSRecord{
+		{
+			Type: "MX",
+			Name: mxHost("badexchange"),
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"exchange": ".mail.example.com",
+			},
+			IntAttrs: map[string]int{
+				"preference": 10,
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDNSRecordsConfig(domain, records),
+				ExpectError: regexp.MustCompile("Invalid Exchange Value"),
+			},
+		},
+	})
+}
+
+// Verifies that a preference above uint16 range is rejected at plan time.
+// The schema-level int64validator.Between(0, 65535) catches this before the
+// Object validator runs, so the error shape differs from other fields.
+func TestAccDNSRecords_mxRecordInvalidPreferenceFailsPlan(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+
+	records := []testAccDNSRecord{
+		{
+			Type: "MX",
+			Name: mxHost("badpref"),
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"exchange": fmt.Sprintf("mail.%s", testAccDomainValue()),
+			},
+			IntAttrs: map[string]int{
+				"preference": 70000,
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDNSRecordsConfig(domain, records),
+				ExpectError: regexp.MustCompile("Invalid Attribute Value"),
+			},
+		},
+	})
+}
+
+// Verifies that an MX record created directly via the API can be adopted by
+// Terraform and that a subsequent plan is empty.
+func TestAccDNSRecords_mxRecordImportPreExisting(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+	host := mxHost("import")
+	exchange := fmt.Sprintf("mail.%s", domain)
+	preference := 10
+
+	preExistingRecord := client.DNSRecord{
+		Type:       "MX",
+		Name:       host,
+		TTL:        3600,
+		Exchange:   exchange,
+		Preference: &preference,
+	}
+
+	preConfig := func() {
+		testClient, err := testAccClient()
+		if err != nil {
+			t.Fatalf("failed to create test client: %v", err)
+		}
+		if err := testClient.UpsertDNSRecords(context.Background(), domain, true, []client.DNSRecord{preExistingRecord}); err != nil {
+			t.Fatalf("failed to pre-seed MX record: %v", err)
+		}
+	}
+
+	t.Cleanup(func() {
+		testClient, err := testAccClient()
+		if err != nil {
+			t.Logf("cleanup: failed to create test client: %v", err)
+			return
+		}
+		if err := testClient.DeleteDNSRecords(context.Background(), domain, []client.DNSRecord{preExistingRecord}); err != nil {
+			t.Logf("cleanup: failed to delete pre-seeded MX record: %v", err)
+		}
+	})
+
+	records := []testAccDNSRecord{
+		{
+			Type: "MX",
+			Name: host,
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"exchange": exchange,
+			},
+			IntAttrs: map[string]int{
+				"preference": preference,
+			},
+		},
+	}
+
+	resourceName := "spaceship_dns_records.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: preConfig,
+				Config:    testAccDNSRecordsConfig(domain, records),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.type", "MX"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.name", host),
+					resource.TestCheckResourceAttr(resourceName, "records.0.exchange", exchange),
+					resource.TestCheckResourceAttr(resourceName, "records.0.preference", fmt.Sprintf("%d", preference)),
+				),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, records),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force", "records"},
+			},
+		},
+		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "MX", host),
+	})
+}
+
+// Verifies that changing preference on an existing MX record converges. The
+// diff signature keys on exchange+preference, so a preference change is a
+// delete+upsert rather than an in-place update — this exercises both paths.
+func TestAccDNSRecords_mxRecordUpdatePreference(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+	host := mxHost("update")
+	exchange := fmt.Sprintf("mail.%s", domain)
+
+	initialRecords := []testAccDNSRecord{
+		{
+			Type: "MX",
+			Name: host,
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"exchange": exchange,
+			},
+			IntAttrs: map[string]int{
+				"preference": 10,
+			},
+		},
+	}
+
+	updatedRecords := []testAccDNSRecord{
+		{
+			Type: "MX",
+			Name: host,
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"exchange": exchange,
+			},
+			IntAttrs: map[string]int{
+				"preference": 20,
+			},
+		},
+	}
+
+	resourceName := "spaceship_dns_records.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSRecordsConfig(domain, initialRecords),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.0.preference", "10"),
+				),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, updatedRecords),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.preference", "20"),
+				),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, updatedRecords),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "MX", host),
+	})
+}
+
+// Verifies that two MX records on the same host with different exchanges
+// coexist. Real-world MX config typically pairs a primary and secondary
+// mail server on the zone apex with different preferences.
+func TestAccDNSRecords_mxRecordMultipleExchangesSameHost(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+	host := mxHost("multi")
+	primary := fmt.Sprintf("mail1.%s", domain)
+	secondary := fmt.Sprintf("mail2.%s", domain)
+
+	records := []testAccDNSRecord{
+		{
+			Type: "MX",
+			Name: host,
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"exchange": primary,
+			},
+			IntAttrs: map[string]int{
+				"preference": 10,
+			},
+		},
+		{
+			Type: "MX",
+			Name: host,
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"exchange": secondary,
+			},
+			IntAttrs: map[string]int{
+				"preference": 20,
+			},
+		},
+	}
+
+	resourceName := "spaceship_dns_records.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSRecordsConfig(domain, records),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.#", "2"),
+				),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, records),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "MX", host),
+	})
+}
+
+// Verifies that exchange matching is case-insensitive end-to-end: applying a
+// mixed-case exchange and re-applying produces an empty plan regardless of
+// what casing the API persists.
+func TestAccDNSRecords_mxRecordExchangeCaseInsensitive(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+	host := mxHost("case")
+
+	records := []testAccDNSRecord{
+		{
+			Type: "MX",
+			Name: host,
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"exchange": fmt.Sprintf("Mail.%s", domain),
+			},
+			IntAttrs: map[string]int{
+				"preference": 10,
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSRecordsConfig(domain, records),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, records),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "MX", host),
+	})
+}
+
+// Verifies that exchange="@" is rejected at plan time. The API returns 422
+// for this value at apply time (empirically confirmed), so the client-layer
+// validator short-circuits with a plan-time error to avoid a failed apply.
+func TestAccDNSRecords_mxRecordApexExchangeFailsPlan(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+
+	records := []testAccDNSRecord{
+		{
+			Type: "MX",
+			Name: mxHost("apexexch"),
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"exchange": "@",
+			},
+			IntAttrs: map[string]int{
+				"preference": 10,
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDNSRecordsConfig(domain, records),
+				ExpectError: regexp.MustCompile("Invalid Exchange Value"),
+			},
+		},
+	})
+}
+
+// Verifies that exchange="*" is rejected at plan time. Same rationale as
+// the apex test: API returns 422 at apply time, so plan-time rejection is
+// the correct UX.
+func TestAccDNSRecords_mxRecordWildcardExchangeFailsPlan(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+
+	records := []testAccDNSRecord{
+		{
+			Type: "MX",
+			Name: mxHost("wildexch"),
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"exchange": "*",
+			},
+			IntAttrs: map[string]int{
+				"preference": 10,
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDNSRecordsConfig(domain, records),
+				ExpectError: regexp.MustCompile("Invalid Exchange Value"),
+			},
+		},
+	})
+}
+
+// Verifies that TTL is actually updatable on an MX record. The API docs
+// omit ttl from MxResourceRecord, but the UI console sets it — this test
+// confirms empirically whether per-record TTL is honored. Creates with
+// TTL=3600, updates to TTL=300, checks state reflects 300, then re-applies
+// the same config with ExpectEmptyPlan to catch any server-side normalization.
+//
+// If this test fails with drift on the final step, the API is silently
+// coercing MX TTL to a default and per-record TTL is effectively read-only.
+func TestAccDNSRecords_mxRecordUpdateTTL(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+	host := mxHost("ttlupdate")
+	exchange := fmt.Sprintf("mail.%s", domain)
+
+	initialRecords := []testAccDNSRecord{
+		{
+			Type: "MX",
+			Name: host,
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"exchange": exchange,
+			},
+			IntAttrs: map[string]int{
+				"preference": 10,
+			},
+		},
+	}
+
+	updatedRecords := []testAccDNSRecord{
+		{
+			Type: "MX",
+			Name: host,
+			TTL:  intPointer(300),
+			StringAttrs: map[string]string{
+				"exchange": exchange,
+			},
+			IntAttrs: map[string]int{
+				"preference": 10,
+			},
+		},
+	}
+
+	resourceName := "spaceship_dns_records.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSRecordsConfig(domain, initialRecords),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.0.ttl", "3600"),
+				),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, updatedRecords),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "records.0.ttl", "300"),
+				),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, updatedRecords),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "MX", host),
+	})
+}
+
+// Verifies that preference=0 (highest priority per RFC 5321) round-trips
+// without being silently coerced or treated as a missing value.
+func TestAccDNSRecords_mxRecordZeroPreference(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+	host := mxHost("zeropref")
+	exchange := fmt.Sprintf("mail.%s", domain)
+
+	records := []testAccDNSRecord{
+		{
+			Type: "MX",
+			Name: host,
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"exchange": exchange,
+			},
+			IntAttrs: map[string]int{
+				"preference": 0,
+			},
+		},
+	}
+
+	resourceName := "spaceship_dns_records.test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSRecordsConfig(domain, records),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "records.0.preference", "0"),
+				),
+			},
+			{
+				Config: testAccDNSRecordsConfig(domain, records),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+		CheckDestroy: testAccCheckDNSRecordAbsent(domain, "MX", host),
+	})
+}

--- a/internal/provider/records/mx_record_validator.go
+++ b/internal/provider/records/mx_record_validator.go
@@ -1,0 +1,95 @@
+package records
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	clientrecords "terraform-provider-spaceship/internal/client/records"
+)
+
+type mxRecordValidator struct{}
+
+var _ validator.Object = &mxRecordValidator{}
+
+func MXValidator() validator.Object {
+	return &mxRecordValidator{}
+}
+
+func (v *mxRecordValidator) Description(_ context.Context) string {
+	return "validates that MX records contain all required fields: exchange and preference"
+}
+
+func (v *mxRecordValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateObject checks MX record-specific fields only.
+// Name and TTL are validated by schema-level attribute validators in the resource schema.
+func (v *mxRecordValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	attrs := req.ConfigValue.Attributes()
+
+	typeAttr, ok := attrs["type"].(types.String)
+	if !ok || typeAttr.IsNull() || typeAttr.IsUnknown() {
+		return
+	}
+
+	if typeAttr.ValueString() != "MX" {
+		return
+	}
+
+	rec := &clientrecords.MXRecord{}
+
+	exchangeAttr, ok := attrs["exchange"].(types.String)
+	if !ok {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("exchange"),
+			"Invalid Field Type",
+			"The 'exchange' field must be a string for MX records.",
+		)
+	} else if exchangeAttr.IsNull() || exchangeAttr.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("exchange"),
+			"Missing Required Field",
+			"The 'exchange' field is required for MX records.",
+		)
+	} else {
+		rec.Exchange = exchangeAttr.ValueString()
+		if err := rec.ValidateExchange(); err != nil {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtName("exchange"),
+				"Invalid Exchange Value",
+				err.Error(),
+			)
+		}
+	}
+
+	preferenceAttr, ok := attrs["preference"].(types.Int64)
+	if !ok {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("preference"),
+			"Invalid Field Type",
+			"The 'preference' field must be an integer for MX records.",
+		)
+	} else if preferenceAttr.IsNull() || preferenceAttr.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("preference"),
+			"Missing Required Field",
+			"The 'preference' field is required for MX records.",
+		)
+	} else {
+		rec.Preference = int(preferenceAttr.ValueInt64())
+		if err := rec.ValidatePreference(); err != nil {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtName("preference"),
+				"Invalid Preference Value",
+				err.Error(),
+			)
+		}
+	}
+}

--- a/internal/provider/srv_record_validator_acc_test.go
+++ b/internal/provider/srv_record_validator_acc_test.go
@@ -97,3 +97,87 @@ func TestAccDNSRecords_srvMissingRequiredFieldsFailsPlan(t *testing.T) {
 		},
 	})
 }
+
+// Verifies that target="@" is rejected at plan time. The API returns 422
+// "target is not a valid domain name" at apply time (empirically confirmed),
+// so the client-layer validator short-circuits with a plan-time error.
+func TestAccDNSRecords_srvRecordApexTargetFailsPlan(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+	prefix := os.Getenv("SPACESHIP_TEST_RECORD_PREFIX")
+	if prefix == "" {
+		prefix = "tfacc"
+	}
+	host := fmt.Sprintf("%s-srv-apextarget", prefix)
+
+	records := []testAccDNSRecord{
+		{
+			Type: "SRV",
+			Name: host,
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"service":  "_sip",
+				"protocol": "_tcp",
+				"target":   "@",
+			},
+			IntAttrs: map[string]int{
+				"priority":    10,
+				"weight":      60,
+				"port_number": 5060,
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDNSRecordsConfig(domain, records),
+				ExpectError: regexp.MustCompile("Invalid Target Value"),
+			},
+		},
+	})
+}
+
+// Verifies that target="*" is rejected at plan time. Same rationale as the
+// apex test: API returns 422 at apply time, plan-time rejection is the
+// correct UX.
+func TestAccDNSRecords_srvRecordWildcardTargetFailsPlan(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+	prefix := os.Getenv("SPACESHIP_TEST_RECORD_PREFIX")
+	if prefix == "" {
+		prefix = "tfacc"
+	}
+	host := fmt.Sprintf("%s-srv-wildtarget", prefix)
+
+	records := []testAccDNSRecord{
+		{
+			Type: "SRV",
+			Name: host,
+			TTL:  intPointer(3600),
+			StringAttrs: map[string]string{
+				"service":  "_sip",
+				"protocol": "_tcp",
+				"target":   "*",
+			},
+			IntAttrs: map[string]int{
+				"priority":    10,
+				"weight":      60,
+				"port_number": 5060,
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDNSRecordsConfig(domain, records),
+				ExpectError: regexp.MustCompile("Invalid Target Value"),
+			},
+		},
+	})
+}


### PR DESCRIPTION
fix: now srv record target rejects `@` and `*` as input