### PR TITLE
refactor(records): simplify single-field DNS record validators

### DIFF
--- a/internal/provider/records/record_a_validator.go
+++ b/internal/provider/records/record_a_validator.go
@@ -43,8 +43,6 @@ func (v *aRecordValidator) ValidateObject(ctx context.Context, req validator.Obj
 		return
 	}
 
-	rec := &clientrecords.ARecord{}
-
 	addressAttr, ok := attrs["address"].(types.String)
 	if !ok {
 		resp.Diagnostics.AddAttributeError(
@@ -52,20 +50,22 @@ func (v *aRecordValidator) ValidateObject(ctx context.Context, req validator.Obj
 			"Invalid Field Type",
 			"The 'address' field must be a string for A records.",
 		)
-	} else if addressAttr.IsNull() || addressAttr.IsUnknown() {
+		return
+	}
+	if addressAttr.IsNull() || addressAttr.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			req.Path.AtName("address"),
 			"Missing Required Field",
 			"The 'address' field is required for A records.",
 		)
-	} else {
-		rec.Address = addressAttr.ValueString()
-		if err := rec.ValidateAddress(); err != nil {
-			resp.Diagnostics.AddAttributeError(
-				req.Path.AtName("address"),
-				"Invalid Address Value",
-				err.Error(),
-			)
-		}
+		return
+	}
+
+	if err := (&clientrecords.ARecord{Address: addressAttr.ValueString()}).ValidateAddress(); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("address"),
+			"Invalid Address Value",
+			err.Error(),
+		)
 	}
 }

--- a/internal/provider/records/record_aaaa_validator.go
+++ b/internal/provider/records/record_aaaa_validator.go
@@ -43,8 +43,6 @@ func (v *aaaaRecordValidator) ValidateObject(ctx context.Context, req validator.
 		return
 	}
 
-	rec := &clientrecords.AAAARecord{}
-
 	addressAttr, ok := attrs["address"].(types.String)
 	if !ok {
 		resp.Diagnostics.AddAttributeError(
@@ -52,20 +50,22 @@ func (v *aaaaRecordValidator) ValidateObject(ctx context.Context, req validator.
 			"Invalid Field Type",
 			"The 'address' field must be a string for AAAA records.",
 		)
-	} else if addressAttr.IsNull() || addressAttr.IsUnknown() {
+		return
+	}
+	if addressAttr.IsNull() || addressAttr.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			req.Path.AtName("address"),
 			"Missing Required Field",
 			"The 'address' field is required for AAAA records.",
 		)
-	} else {
-		rec.Address = addressAttr.ValueString()
-		if err := rec.ValidateAddress(); err != nil {
-			resp.Diagnostics.AddAttributeError(
-				req.Path.AtName("address"),
-				"Invalid Address Value",
-				err.Error(),
-			)
-		}
+		return
+	}
+
+	if err := (&clientrecords.AAAARecord{Address: addressAttr.ValueString()}).ValidateAddress(); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("address"),
+			"Invalid Address Value",
+			err.Error(),
+		)
 	}
 }

--- a/internal/provider/records/record_alias_validator.go
+++ b/internal/provider/records/record_alias_validator.go
@@ -43,8 +43,6 @@ func (v *aliasRecordValidator) ValidateObject(ctx context.Context, req validator
 		return
 	}
 
-	rec := &clientrecords.ALIASRecord{}
-
 	aliasNameAttr, ok := attrs["alias_name"].(types.String)
 	if !ok {
 		resp.Diagnostics.AddAttributeError(
@@ -52,20 +50,22 @@ func (v *aliasRecordValidator) ValidateObject(ctx context.Context, req validator
 			"Invalid Field Type",
 			"The 'alias_name' field must be a string for ALIAS records.",
 		)
-	} else if aliasNameAttr.IsNull() || aliasNameAttr.IsUnknown() {
+		return
+	}
+	if aliasNameAttr.IsNull() || aliasNameAttr.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			req.Path.AtName("alias_name"),
 			"Missing Required Field",
 			"The 'alias_name' field is required for ALIAS records.",
 		)
-	} else {
-		rec.AliasName = aliasNameAttr.ValueString()
-		if err := rec.ValidateAliasName(); err != nil {
-			resp.Diagnostics.AddAttributeError(
-				req.Path.AtName("alias_name"),
-				"Invalid Alias Name Value",
-				err.Error(),
-			)
-		}
+		return
+	}
+
+	if err := (&clientrecords.ALIASRecord{AliasName: aliasNameAttr.ValueString()}).ValidateAliasName(); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("alias_name"),
+			"Invalid Alias Name Value",
+			err.Error(),
+		)
 	}
 }

--- a/internal/provider/records/record_cname_validator.go
+++ b/internal/provider/records/record_cname_validator.go
@@ -43,8 +43,6 @@ func (v *cnameRecordValidator) ValidateObject(ctx context.Context, req validator
 		return
 	}
 
-	rec := &clientrecords.CNAMERecord{}
-
 	cnameAttr, ok := attrs["cname"].(types.String)
 	if !ok {
 		resp.Diagnostics.AddAttributeError(
@@ -52,20 +50,22 @@ func (v *cnameRecordValidator) ValidateObject(ctx context.Context, req validator
 			"Invalid Field Type",
 			"The 'cname' field must be a string for CNAME records.",
 		)
-	} else if cnameAttr.IsNull() || cnameAttr.IsUnknown() {
+		return
+	}
+	if cnameAttr.IsNull() || cnameAttr.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			req.Path.AtName("cname"),
 			"Missing Required Field",
 			"The 'cname' field is required for CNAME records.",
 		)
-	} else {
-		rec.CName = cnameAttr.ValueString()
-		if err := rec.ValidateCName(); err != nil {
-			resp.Diagnostics.AddAttributeError(
-				req.Path.AtName("cname"),
-				"Invalid CName Value",
-				err.Error(),
-			)
-		}
+		return
+	}
+
+	if err := (&clientrecords.CNAMERecord{CName: cnameAttr.ValueString()}).ValidateCName(); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("cname"),
+			"Invalid CName Value",
+			err.Error(),
+		)
 	}
 }

--- a/internal/provider/records/record_ns_validator.go
+++ b/internal/provider/records/record_ns_validator.go
@@ -43,8 +43,6 @@ func (v *nsRecordValidator) ValidateObject(ctx context.Context, req validator.Ob
 		return
 	}
 
-	rec := &clientrecords.NSRecord{}
-
 	nameserverAttr, ok := attrs["nameserver"].(types.String)
 	if !ok {
 		resp.Diagnostics.AddAttributeError(
@@ -52,20 +50,22 @@ func (v *nsRecordValidator) ValidateObject(ctx context.Context, req validator.Ob
 			"Invalid Field Type",
 			"The 'nameserver' field must be a string for NS records.",
 		)
-	} else if nameserverAttr.IsNull() || nameserverAttr.IsUnknown() {
+		return
+	}
+	if nameserverAttr.IsNull() || nameserverAttr.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			req.Path.AtName("nameserver"),
 			"Missing Required Field",
 			"The 'nameserver' field is required for NS records.",
 		)
-	} else {
-		rec.Nameserver = nameserverAttr.ValueString()
-		if err := rec.ValidateNameserver(); err != nil {
-			resp.Diagnostics.AddAttributeError(
-				req.Path.AtName("nameserver"),
-				"Invalid Nameserver Value",
-				err.Error(),
-			)
-		}
+		return
+	}
+
+	if err := (&clientrecords.NSRecord{Nameserver: nameserverAttr.ValueString()}).ValidateNameserver(); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("nameserver"),
+			"Invalid Nameserver Value",
+			err.Error(),
+		)
 	}
 }

--- a/internal/provider/records/record_ptr_validator.go
+++ b/internal/provider/records/record_ptr_validator.go
@@ -43,8 +43,6 @@ func (v *ptrRecordValidator) ValidateObject(ctx context.Context, req validator.O
 		return
 	}
 
-	rec := &clientrecords.PTRRecord{}
-
 	pointerAttr, ok := attrs["pointer"].(types.String)
 	if !ok {
 		resp.Diagnostics.AddAttributeError(
@@ -52,20 +50,22 @@ func (v *ptrRecordValidator) ValidateObject(ctx context.Context, req validator.O
 			"Invalid Field Type",
 			"The 'pointer' field must be a string for PTR records.",
 		)
-	} else if pointerAttr.IsNull() || pointerAttr.IsUnknown() {
+		return
+	}
+	if pointerAttr.IsNull() || pointerAttr.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			req.Path.AtName("pointer"),
 			"Missing Required Field",
 			"The 'pointer' field is required for PTR records.",
 		)
-	} else {
-		rec.Pointer = pointerAttr.ValueString()
-		if err := rec.ValidatePointer(); err != nil {
-			resp.Diagnostics.AddAttributeError(
-				req.Path.AtName("pointer"),
-				"Invalid Pointer Value",
-				err.Error(),
-			)
-		}
+		return
+	}
+
+	if err := (&clientrecords.PTRRecord{Pointer: pointerAttr.ValueString()}).ValidatePointer(); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("pointer"),
+			"Invalid Pointer Value",
+			err.Error(),
+		)
 	}
 }

--- a/internal/provider/records/record_txt_validator.go
+++ b/internal/provider/records/record_txt_validator.go
@@ -43,8 +43,6 @@ func (v *txtRecordValidator) ValidateObject(ctx context.Context, req validator.O
 		return
 	}
 
-	rec := &clientrecords.TXTRecord{}
-
 	valueAttr, ok := attrs["value"].(types.String)
 	if !ok {
 		resp.Diagnostics.AddAttributeError(
@@ -52,20 +50,22 @@ func (v *txtRecordValidator) ValidateObject(ctx context.Context, req validator.O
 			"Invalid Field Type",
 			"The 'value' field must be a string for TXT records.",
 		)
-	} else if valueAttr.IsNull() || valueAttr.IsUnknown() {
+		return
+	}
+	if valueAttr.IsNull() || valueAttr.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			req.Path.AtName("value"),
 			"Missing Required Field",
 			"The 'value' field is required for TXT records.",
 		)
-	} else {
-		rec.Value = valueAttr.ValueString()
-		if err := rec.ValidateValue(); err != nil {
-			resp.Diagnostics.AddAttributeError(
-				req.Path.AtName("value"),
-				"Invalid Value",
-				err.Error(),
-			)
-		}
+		return
+	}
+
+	if err := (&clientrecords.TXTRecord{Value: valueAttr.ValueString()}).ValidateValue(); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("value"),
+			"Invalid Value",
+			err.Error(),
+		)
 	}
 }


### PR DESCRIPTION
## Summary

Refactor the seven single-field DNS record validators (A, AAAA, ALIAS, CNAME, NS, PTR, TXT) for readability. No behaviour change.

> **Scope note:** an earlier revision of this PR also renamed the TLSA/HTTPS/SVCB diagnostic titles for consistent word spacing. Per review (dm1tr1yvovk), that half was dropped — the previous titles mirror the Go struct field names, the diagnostic `Path` already carries the snake_case schema name, and renaming is an observable breaking change for anyone matching diagnostic text, with no schema/state change to justify it. Only the refactor remains.

## Change

Each of the seven validators allocated an empty client record struct, set its single field, then validated it inside the trailing branch of an `if/else-if/else` chain. The intermediate struct served no purpose beyond that one call.

They now use guard clauses (early return on the type assertion and null/unknown checks) and inline the one-field struct into the validation call.

Behaviour is unchanged: each validator checks a single field, so the early returns are equivalent to the previous trailing `else`, and each still emits exactly one diagnostic. Multi-field validators (CAA, MX, SRV, TLSA, HTTPS, SVCB) are **intentionally left as-is** — they accumulate diagnostics across several fields, so an early-return rewrite would drop errors.

## Verification

- `go build ./...` — ok
- `go vet ./...` — clean
- `gofmt -l internal/` — clean
- `go test ./internal/provider/records/...` (unit) — pass
- `golangci-lint run ./...` — **0 issues**

Acceptance tests not run (hit the real Spaceship API); no acc-test changes in this revision.
