### PR TITLE
ci: install latest matching Go patch in setup-go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
               uses: actions/setup-go@v6
               with:
                   go-version-file: go.mod
+                  check-latest: true
 
             - name: Lint
               uses: golangci/golangci-lint-action@v9
@@ -114,6 +115,7 @@ jobs:
               uses: actions/setup-go@v6
               with:
                   go-version-file: go.mod
+                  check-latest: true
 
             - name: Set up Terraform
               if: ${{ steps.acc_secrets.outputs.has_secrets == 'true' }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,6 +49,7 @@ jobs:
               uses: actions/setup-go@v6
               with:
                   go-version-file: go.mod
+                  check-latest: true
 
             - name: Initialize CodeQL
               uses: github/codeql-action/init@v4


### PR DESCRIPTION
## Summary

Add `check-latest: true` to every `actions/setup-go@v6` step so CI installs the latest Go patch matching `go.mod` instead of reusing whatever patch is pre-cached on the runner image.

By default `setup-go` will use a pre-installed Go on the runner if it satisfies the version spec, which can be several patches behind the toolchain `go.mod` requests. `check-latest: true` forces a check for the newest matching release.

## Changed

- `ci.yml` — both jobs (Check, Acceptance Tests)
- `codeql.yml`
- `release.yml`

Each step keeps `go-version-file: go.mod`; only the new line is added.

## Verification

- YAML parses (`yaml.safe_load`) for all three files
- Diff is 4 added lines, no other changes
