### PR TITLE
feat: dns record read cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.15.0
+	golang.org/x/sync v0.19.0
 )
 
 require (
@@ -53,7 +54,6 @@ require (
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect

--- a/internal/client/dns.go
+++ b/internal/client/dns.go
@@ -121,14 +121,25 @@ func (c *Client) FindDNSRecord(ctx context.Context, domain, recordType, name, si
 		return DNSRecord{}, err
 	}
 
+	if record, ok := MatchDNSRecord(records, recordType, name, signature); ok {
+		return record, nil
+	}
+	return DNSRecord{}, ErrRecordNotFound
+}
+
+// MatchDNSRecord scans an already-fetched record slice for the one matching the
+// API identity (type, name, data signature) and reports whether it was found.
+// Matching uses RecordKey, so it follows the API's case rules. Splitting this
+// out from FindDNSRecord lets callers that already hold the records (e.g. a
+// cache) reuse the exact same match logic without re-fetching.
+func MatchDNSRecord(records []DNSRecord, recordType, name, signature string) (DNSRecord, bool) {
 	target := strings.ToUpper(recordType) + "|" + strings.ToLower(name) + "|" + signature
 	for _, record := range records {
 		if RecordKey(record) == target {
-			return record, nil
+			return record, true
 		}
 	}
-
-	return DNSRecord{}, ErrRecordNotFound
+	return DNSRecord{}, false
 }
 
 // filterCustomDNSRecords returns only records whose group type is "custom"

--- a/internal/provider/dns_record_cache.go
+++ b/internal/provider/dns_record_cache.go
@@ -16,11 +16,15 @@ import (
 // zone, so N records in one domain cost N full zone reads. The cache collapses
 // that into one read per domain.
 //
-// Correctness rests on write-invalidation: any mutation of a domain's records
-// must call Invalidate(domain) so a later Find re-fetches instead of serving
-// stale data. The cache deliberately lives in the provider layer (not the
-// client) so the client stays a cache-free, reusable API surface — which means
-// the client cannot invalidate on its own, and callers own that responsibility.
+// Correctness rests on write-invalidation: every resource that reads through
+// the cache must call Invalidate(domain) after mutating that domain's records,
+// so a later Find re-fetches instead of serving stale data. The plural
+// spaceship_dns_records resource deliberately does not participate (neither
+// reading nor invalidating): mixing it with the singular resource on one
+// domain is documented as unsupported, so the cache does not defend against
+// that configuration. The cache lives in the provider layer (not the client)
+// so the client stays a cache-free, reusable API surface — which means the
+// client cannot invalidate on its own, and callers own that responsibility.
 type dnsRecordCache struct {
 	client *client.Client
 
@@ -79,8 +83,13 @@ func (c *dnsRecordCache) records(ctx context.Context, domain string) ([]client.D
 	// is held only around the map, never across the network call. A caller that
 	// arrives just after a flight completes (and the key is forgotten) simply
 	// runs one extra fetch — never stale, just an occasional redundant read.
-	result, err, _ := c.sf.Do(domain, func() (any, error) {
-		records, err := c.client.GetDNSRecords(ctx, domain)
+	//
+	// DoChan + select lets each caller observe its own context cancellation,
+	// and context.WithoutCancel detaches the shared fetch from any single
+	// caller's ctx so one caller's cancellation can't fail waiters that still
+	// need the result.
+	ch := c.sf.DoChan(domain, func() (any, error) {
+		records, err := c.client.GetDNSRecords(context.WithoutCancel(ctx), domain)
 		if err != nil {
 			return nil, err
 		}
@@ -89,8 +98,14 @@ func (c *dnsRecordCache) records(ctx context.Context, domain string) ([]client.D
 		c.mu.Unlock()
 		return records, nil
 	})
-	if err != nil {
-		return nil, err
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-ch:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		return res.Val.([]client.DNSRecord), nil
 	}
-	return result.([]client.DNSRecord), nil
 }

--- a/internal/provider/dns_record_cache.go
+++ b/internal/provider/dns_record_cache.go
@@ -1,0 +1,96 @@
+package provider
+
+import (
+	"context"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+
+	"terraform-provider-spaceship/internal/client"
+)
+
+// dnsRecordCache memoizes per-domain DNS record fetches for the lifetime of a
+// provider process (i.e. a single Terraform command). The singular
+// spaceship_dns_record resource calls Find once per managed record during a
+// refresh; without this cache each call re-fetches and paginates the whole
+// zone, so N records in one domain cost N full zone reads. The cache collapses
+// that into one read per domain.
+//
+// Correctness rests on write-invalidation: any mutation of a domain's records
+// must call Invalidate(domain) so a later Find re-fetches instead of serving
+// stale data. The cache deliberately lives in the provider layer (not the
+// client) so the client stays a cache-free, reusable API surface — which means
+// the client cannot invalidate on its own, and callers own that responsibility.
+type dnsRecordCache struct {
+	client *client.Client
+
+	// sf collapses a cold-start stampede. Terraform refreshes resources
+	// concurrently (default parallelism 10), so the first wave of Find calls
+	// for a domain would otherwise each launch a full fetch. singleflight runs
+	// a single fetch per key; the rest wait on it and share the result.
+	sf singleflight.Group
+
+	mu      sync.Mutex
+	entries map[string][]client.DNSRecord
+}
+
+func newDNSRecordCache(c *client.Client) *dnsRecordCache {
+	return &dnsRecordCache{
+		client:  c,
+		entries: make(map[string][]client.DNSRecord),
+	}
+}
+
+// Find returns the custom-group record matching the API identity (type, name,
+// signature) for the domain, serving from cache when warm. It returns
+// client.ErrRecordNotFound when no record matches — same contract as
+// client.FindDNSRecord, so callers can swap one for the other.
+func (c *dnsRecordCache) Find(ctx context.Context, domain, recordType, name, signature string) (client.DNSRecord, error) {
+	records, err := c.records(ctx, domain)
+	if err != nil {
+		return client.DNSRecord{}, err
+	}
+	if record, ok := client.MatchDNSRecord(records, recordType, name, signature); ok {
+		return record, nil
+	}
+	return client.DNSRecord{}, client.ErrRecordNotFound
+}
+
+// Invalidate drops a domain's cached records so the next Find re-fetches. Call
+// it after every successful write (create/update/delete) to that domain.
+func (c *dnsRecordCache) Invalidate(domain string) {
+	c.mu.Lock()
+	delete(c.entries, domain)
+	c.mu.Unlock()
+}
+
+// records returns the domain's custom-group records, serving the cached slice
+// on a hit and fetching via client.GetDNSRecords on a miss.
+func (c *dnsRecordCache) records(ctx context.Context, domain string) ([]client.DNSRecord, error) {
+	c.mu.Lock()
+	if records, ok := c.entries[domain]; ok {
+		c.mu.Unlock()
+		return records, nil
+	}
+	c.mu.Unlock()
+
+	// Cache miss: fetch once across concurrent callers. singleflight collapses
+	// the cold-start stampede so a whole refresh wave shares one fetch. The mutex
+	// is held only around the map, never across the network call. A caller that
+	// arrives just after a flight completes (and the key is forgotten) simply
+	// runs one extra fetch — never stale, just an occasional redundant read.
+	result, err, _ := c.sf.Do(domain, func() (any, error) {
+		records, err := c.client.GetDNSRecords(ctx, domain)
+		if err != nil {
+			return nil, err
+		}
+		c.mu.Lock()
+		c.entries[domain] = records
+		c.mu.Unlock()
+		return records, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]client.DNSRecord), nil
+}

--- a/internal/provider/dns_record_cache_test.go
+++ b/internal/provider/dns_record_cache_test.go
@@ -1,0 +1,166 @@
+package provider
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"terraform-provider-spaceship/internal/client"
+)
+
+// newCountingRecordCache returns a cache backed by a mock API plus a counter of
+// how many record-list fetches reached the server. For record sets under one
+// page, one GetDNSRecords call == one GET, so the counter measures cache misses.
+func newCountingRecordCache(t *testing.T, items []map[string]any) (*dnsRecordCache, *int64) {
+	t.Helper()
+
+	var gets int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		atomic.AddInt64(&gets, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "total": len(items)})
+	}))
+	t.Cleanup(server.Close)
+
+	c, err := client.NewClient(server.URL, "k", "s")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return newDNSRecordCache(c), &gets
+}
+
+// A warm cache serves repeated Find calls for the same domain from a single fetch.
+func TestDNSRecordCache_CachesRepeatedReads(t *testing.T) {
+	cache, gets := newCountingRecordCache(t, []map[string]any{
+		{"type": "A", "name": "@", "ttl": 3600, "address": "1.2.3.4"},
+		{"type": "A", "name": "www", "ttl": 3600, "address": "5.6.7.8"},
+	})
+
+	for range 5 {
+		rec, err := cache.Find(t.Context(), "example.com", "A", "@", "1.2.3.4")
+		if err != nil {
+			t.Fatalf("Find: %v", err)
+		}
+		if rec.Address != "1.2.3.4" {
+			t.Fatalf("expected 1.2.3.4, got %q", rec.Address)
+		}
+	}
+
+	if got := atomic.LoadInt64(gets); got != 1 {
+		t.Fatalf("expected 1 underlying fetch, got %d", got)
+	}
+}
+
+// Invalidate forces the next Find to re-fetch.
+func TestDNSRecordCache_InvalidateForcesRefetch(t *testing.T) {
+	cache, gets := newCountingRecordCache(t, []map[string]any{
+		{"type": "A", "name": "@", "ttl": 3600, "address": "1.2.3.4"},
+	})
+
+	if _, err := cache.Find(t.Context(), "example.com", "A", "@", "1.2.3.4"); err != nil {
+		t.Fatalf("first Find: %v", err)
+	}
+	cache.Invalidate("example.com")
+	if _, err := cache.Find(t.Context(), "example.com", "A", "@", "1.2.3.4"); err != nil {
+		t.Fatalf("second Find: %v", err)
+	}
+
+	if got := atomic.LoadInt64(gets); got != 2 {
+		t.Fatalf("expected 2 fetches after invalidation, got %d", got)
+	}
+}
+
+// A missing record returns client.ErrRecordNotFound, not an error.
+func TestDNSRecordCache_FindMissingReturnsNotFound(t *testing.T) {
+	cache, _ := newCountingRecordCache(t, []map[string]any{
+		{"type": "A", "name": "@", "ttl": 3600, "address": "1.2.3.4"},
+	})
+
+	_, err := cache.Find(t.Context(), "example.com", "A", "missing", "9.9.9.9")
+	if !errors.Is(err, client.ErrRecordNotFound) {
+		t.Fatalf("expected ErrRecordNotFound, got %v", err)
+	}
+}
+
+// A failed fetch is not cached — the next Find retries and succeeds.
+func TestDNSRecordCache_ErrorNotCached(t *testing.T) {
+	var gets int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt64(&gets, 1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{{"type": "A", "name": "@", "ttl": 3600, "address": "1.2.3.4"}},
+			"total": 1,
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	c, err := client.NewClient(server.URL, "k", "s")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	cache := newDNSRecordCache(c)
+
+	if _, err := cache.Find(t.Context(), "example.com", "A", "@", "1.2.3.4"); err == nil {
+		t.Fatal("expected first Find to fail")
+	}
+	if _, err := cache.Find(t.Context(), "example.com", "A", "@", "1.2.3.4"); err != nil {
+		t.Fatalf("second Find: %v", err)
+	}
+}
+
+// Invalidate evicts only the given domain; other domains stay cached.
+func TestDNSRecordCache_InvalidateIsPerDomain(t *testing.T) {
+	cache, gets := newCountingRecordCache(t, []map[string]any{
+		{"type": "A", "name": "@", "ttl": 3600, "address": "1.2.3.4"},
+	})
+
+	for _, domain := range []string{"a.com", "b.com"} {
+		if _, err := cache.Find(t.Context(), domain, "A", "@", "1.2.3.4"); err != nil {
+			t.Fatalf("warm Find %s: %v", domain, err)
+		}
+	}
+	cache.Invalidate("a.com")
+	for _, domain := range []string{"a.com", "b.com"} {
+		if _, err := cache.Find(t.Context(), domain, "A", "@", "1.2.3.4"); err != nil {
+			t.Fatalf("post-invalidate Find %s: %v", domain, err)
+		}
+	}
+
+	// 2 warm-up fetches + 1 re-fetch for a.com; b.com stays cached.
+	if got := atomic.LoadInt64(gets); got != 3 {
+		t.Fatalf("expected 3 fetches, got %d", got)
+	}
+}
+
+// Concurrent cold-cache Find calls collapse into a single fetch (singleflight).
+func TestDNSRecordCache_ConcurrentReadsCollapse(t *testing.T) {
+	cache, gets := newCountingRecordCache(t, []map[string]any{
+		{"type": "A", "name": "@", "ttl": 3600, "address": "1.2.3.4"},
+	})
+
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = cache.Find(t.Context(), "example.com", "A", "@", "1.2.3.4")
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt64(gets); got != 1 {
+		t.Fatalf("expected concurrent reads to collapse into 1 fetch, got %d", got)
+	}
+}

--- a/internal/provider/dns_record_cache_test.go
+++ b/internal/provider/dns_record_cache_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -141,6 +142,61 @@ func TestDNSRecordCache_InvalidateIsPerDomain(t *testing.T) {
 	// 2 warm-up fetches + 1 re-fetch for a.com; b.com stays cached.
 	if got := atomic.LoadInt64(gets); got != 3 {
 		t.Fatalf("expected 3 fetches, got %d", got)
+	}
+}
+
+// A cancelled caller fails alone; waiters sharing the same in-flight fetch
+// still get the result.
+func TestDNSRecordCache_CancelledCallerDoesNotFailWaiters(t *testing.T) {
+	var once sync.Once
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		once.Do(func() { close(started) })
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{{"type": "A", "name": "@", "ttl": 3600, "address": "1.2.3.4"}},
+			"total": 1,
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	c, err := client.NewClient(server.URL, "k", "s")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	cache := newDNSRecordCache(c)
+
+	// Leader starts the flight, then gets cancelled while the fetch is blocked.
+	leaderCtx, cancel := context.WithCancel(t.Context())
+	leaderErr := make(chan error, 1)
+	go func() {
+		_, err := cache.Find(leaderCtx, "example.com", "A", "@", "1.2.3.4")
+		leaderErr <- err
+	}()
+	<-started
+	cancel()
+	if err := <-leaderErr; !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled for cancelled caller, got %v", err)
+	}
+
+	// Waiters with live contexts join the same flight and must still succeed.
+	var wg sync.WaitGroup
+	errs := make([]error, 3)
+	for i := range errs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, errs[i] = cache.Find(t.Context(), "example.com", "A", "@", "1.2.3.4")
+		}()
+	}
+	close(release)
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("waiter %d: %v", i, err)
+		}
 	}
 }
 

--- a/internal/provider/dns_record_resource.go
+++ b/internal/provider/dns_record_resource.go
@@ -26,6 +26,10 @@ func NewDNSRecordResource() resource.Resource {
 
 type dnsRecordResource struct {
 	client *client.Client
+	// records is the shared per-domain read cache. Read/Update fetch through it
+	// so N records in one domain cost one zone fetch instead of N; every write
+	// path invalidates the domain so later reads never serve stale data.
+	records *dnsRecordCache
 }
 
 type dnsRecordResourceModel struct {
@@ -100,12 +104,13 @@ func (r *dnsRecordResource) Configure(_ context.Context, req resource.ConfigureR
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.Client)
+	pd, ok := req.ProviderData.(*providerData)
 	if !ok {
-		resp.Diagnostics.AddError("Unexpected provider data type", fmt.Sprintf("Expected *client.Client, got %T", req.ProviderData))
+		resp.Diagnostics.AddError("Unexpected provider data type", fmt.Sprintf("Expected *providerData, got %T", req.ProviderData))
 		return
 	}
-	r.client = client
+	r.client = pd.Client
+	r.records = pd.DNSRecords
 }
 
 func (r *dnsRecordResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -143,6 +148,7 @@ func (r *dnsRecordResource) Create(ctx context.Context, req resource.CreateReque
 		resp.Diagnostics.AddError("Spaceship API error", fmt.Sprintf("Failed to create DNS record: %s", err))
 		return
 	}
+	r.records.Invalidate(domain)
 
 	// Only `id` is computed — every other attribute came from the user's plan
 	// and is already populated on `plan`. Setting other fields here would
@@ -197,6 +203,7 @@ func (r *dnsRecordResource) Delete(ctx context.Context, req resource.DeleteReque
 		resp.Diagnostics.AddError("Spaceship API error", fmt.Sprintf("Failed to delete DNS record: %s", err))
 		return
 	}
+	r.records.Invalidate(domain)
 
 	resp.State.RemoveResource(ctx)
 
@@ -223,7 +230,7 @@ func (r *dnsRecordResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	record, err := r.client.FindDNSRecord(ctx, domain, recordType, name, signature)
+	record, err := r.records.Find(ctx, domain, recordType, name, signature)
 	if errors.Is(err, client.ErrRecordNotFound) {
 		// Record no longer exists in the custom group — drop it from state so
 		// Terraform will plan a recreate on the next apply.
@@ -265,7 +272,7 @@ func (r *dnsRecordResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	record, err := r.client.FindDNSRecord(ctx, domain, recordType, name, signature)
+	record, err := r.records.Find(ctx, domain, recordType, name, signature)
 	if errors.Is(err, client.ErrRecordNotFound) {
 		resp.Diagnostics.AddError(
 			"DNS record not found",
@@ -284,6 +291,7 @@ func (r *dnsRecordResource) Update(ctx context.Context, req resource.UpdateReque
 		resp.Diagnostics.AddError("Spaceship API error", fmt.Sprintf("Failed to update DNS record TTL: %s", err))
 		return
 	}
+	r.records.Invalidate(domain)
 
 	// Data signature unchanged, so the composite ID remains stable.
 	plan.ID = state.ID

--- a/internal/provider/dns_records_resource.go
+++ b/internal/provider/dns_records_resource.go
@@ -100,12 +100,12 @@ func (r *dnsRecordsResource) Configure(_ context.Context, req resource.Configure
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.Client)
+	pd, ok := req.ProviderData.(*providerData)
 	if !ok {
-		resp.Diagnostics.AddError("Unexpected provider data type", fmt.Sprintf("Expected *client.Client, got %T", req.ProviderData))
+		resp.Diagnostics.AddError("Unexpected provider data type", fmt.Sprintf("Expected *providerData, got %T", req.ProviderData))
 		return
 	}
-	r.client = client
+	r.client = pd.Client
 }
 
 func (r *dnsRecordsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/domain_info_data_source.go
+++ b/internal/provider/domain_info_data_source.go
@@ -74,11 +74,11 @@ func (d *domainInfoDataSource) Configure(_ context.Context, req datasource.Confi
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.Client)
+	pd, ok := req.ProviderData.(*providerData)
 	if !ok {
-		resp.Diagnostics.AddError("Unexpected provider data type", fmt.Sprintf("Expected *client.Client, got %T", req.ProviderData))
+		resp.Diagnostics.AddError("Unexpected provider data type", fmt.Sprintf("Expected *providerData, got %T", req.ProviderData))
 		return
 	}
 
-	d.client = client
+	d.client = pd.Client
 }

--- a/internal/provider/domain_list_data_source.go
+++ b/internal/provider/domain_list_data_source.go
@@ -95,12 +95,12 @@ func (r *domainListDataSource) Configure(_ context.Context, req datasource.Confi
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.Client)
+	pd, ok := req.ProviderData.(*providerData)
 
 	if !ok {
-		resp.Diagnostics.AddError("Unexpected provider data type", fmt.Sprintf("Expected *client.Client, got %T", req.ProviderData))
+		resp.Diagnostics.AddError("Unexpected provider data type", fmt.Sprintf("Expected *providerData, got %T", req.ProviderData))
 		return
 	}
 
-	r.client = client
+	r.client = pd.Client
 }

--- a/internal/provider/domain_resource.go
+++ b/internal/provider/domain_resource.go
@@ -276,13 +276,13 @@ func (d *domainResource) Configure(ctx context.Context, req resource.ConfigureRe
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.Client)
+	pd, ok := req.ProviderData.(*providerData)
 	if !ok {
-		resp.Diagnostics.AddError("Unexpected provider data type", fmt.Sprintf("Expected *client.Client got %T", req.ProviderData))
+		resp.Diagnostics.AddError("Unexpected provider data type", fmt.Sprintf("Expected *providerData, got %T", req.ProviderData))
 		return
 	}
 
-	d.client = client
+	d.client = pd.Client
 }
 
 func (d *domainResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/personal_nameserver_resource.go
+++ b/internal/provider/personal_nameserver_resource.go
@@ -95,12 +95,12 @@ func (r *personalNameserverResource) Configure(_ context.Context, req resource.C
 		return
 	}
 
-	c, ok := req.ProviderData.(*client.Client)
+	pd, ok := req.ProviderData.(*providerData)
 	if !ok {
-		resp.Diagnostics.AddError("Unexpected provider data type", fmt.Sprintf("Expected *client.Client, got %T", req.ProviderData))
+		resp.Diagnostics.AddError("Unexpected provider data type", fmt.Sprintf("Expected *providerData, got %T", req.ProviderData))
 		return
 	}
-	r.client = c
+	r.client = pd.Client
 }
 
 func (r *personalNameserverResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -124,8 +124,25 @@ func (p *spaceshipProvider) Configure(ctx context.Context, req provider.Configur
 		"base_url": defaultBaseURL,
 	})
 
-	resp.DataSourceData = client
-	resp.ResourceData = client
+	// All resources and data sources receive the same providerData: the raw
+	// client plus a shared DNS-record cache. The cache lives here (and not on
+	// the client) so the client stays a pure API client; it is per-process and
+	// thus naturally scoped to a single Terraform command.
+	pd := &providerData{
+		Client:     client,
+		DNSRecords: newDNSRecordCache(client),
+	}
+	resp.DataSourceData = pd
+	resp.ResourceData = pd
+}
+
+// providerData is the shared dependency bundle handed to every resource and
+// data source through ProviderData. Resources that only talk to the API read
+// Client; the singular dns_record resource additionally uses DNSRecords to
+// collapse its many per-record reads into one fetch per domain.
+type providerData struct {
+	Client     *client.Client
+	DNSRecords *dnsRecordCache
 }
 
 func (p *spaceshipProvider) Resources(_ context.Context) []func() resource.Resource {


### PR DESCRIPTION
## Why

Every `spaceship_dns_record` resource re-fetched (and re-paginated) the entire zone on refresh, so N records in one domain cost N full zone reads per `terraform plan`/`apply`. With large configs this is slow and burns API rate limit for no reason.

## What

- **Shared per-domain read cache** (`dnsRecordCache`): `Read`/`Update` of `spaceship_dns_record` fetch through it, collapsing N reads into one zone fetch per domain per Terraform command. `singleflight` collapses the cold-start stampede from Terraform's concurrent refresh (default parallelism 10) into a single fetch.
- **Write invalidation**: every write path of the singular resource (create / TTL update / delete) invalidates its domain, so subsequent reads re-fetch. Fetch errors are never cached.
- **`providerData` bundle**: resources and data sources now receive `{Client, DNSRecords}` via `ProviderData` instead of the raw client, hence the mechanical `Configure` changes across all resources.
- **`client.MatchDNSRecord`** extracted from `FindDNSRecord` so the cache reuses the exact API matching rules (case-insensitive except TXT values) without duplicating them.
- `golang.org/x/sync` promoted to a direct dependency.

## Scope notes

- The plural `spaceship_dns_records` resource intentionally does **not** participate in the cache: mixing it with singular records on one domain is already documented as unsupported, so the cache doesn't defend against that configuration.
- The cache is per-process, i.e. naturally scoped to a single Terraform command — no TTL/expiry needed.

## Testing

Unit tests cover cache hits, write-invalidation (including per-domain scope), singleflight collapse under 20 concurrent readers, error-not-cached recovery, and the `ErrRecordNotFound` contract. `make test`, `make lint`, and `go build` all pass.
