### PR TITLE
ci: add Trivy, govulncheck, SBOM and a consolidated PR security summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,210 @@ jobs:
                   fi
                   make docs-validate
 
+    security:
+        # Trivy covers four concerns in one job: SCA (CVEs in Go dependencies),
+        # IaC misconfig (Terraform / YAML), committed secrets, and license
+        # policy. A separate step emits a CycloneDX SBOM artifact so downstream
+        # tooling can consume an inventory without re-running the scan.
+        name: Security scan (Trivy)
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+            - name: Trivy vuln + misconfig + secret + license scan
+              uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+              with:
+                  # Pin the Trivy binary to a specific scanner release rather than
+                  # the action's bundled default, so scan behavior is reproducible.
+                  # Dependabot bumps the action SHA but NOT this input — bump by
+                  # hand after reviewing https://github.com/aquasecurity/trivy/releases.
+                  version: v0.71.1
+                  scan-type: fs
+                  scan-ref: .
+                  scanners: vuln,misconfig,secret,license
+                  severity: CRITICAL,HIGH
+                  ignore-unfixed: true
+                  exit-code: "1"
+                  format: table
+                  # License denylist lives in trivy.yaml at the repo root; the
+                  # action auto-loads it before each scanner runs.
+                  trivy-config: trivy.yaml
+                  cache: "true"
+
+            - name: Trivy report (JSON, all severities, non-gating)
+              # Second Trivy pass that NEVER gates (exit-code 0) and drops the
+              # CRITICAL,HIGH + ignore-unfixed filters of the gating scan above,
+              # so the PR summary can show the full picture (medium/low + unfixed).
+              # Consumed only by the security-report job.
+              if: ${{ !cancelled() }}
+              uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+              with:
+                  version: v0.71.1
+                  scan-type: fs
+                  scan-ref: .
+                  scanners: vuln,misconfig,secret,license
+                  exit-code: "0"
+                  format: json
+                  output: trivy-results.json
+                  trivy-config: trivy.yaml
+                  cache: "true"
+
+            - name: Upload Trivy JSON report
+              if: ${{ !cancelled() }}
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: trivy-json
+                  path: trivy-results.json
+                  retention-days: 90
+
+            - name: Generate CycloneDX SBOM
+              # Runs even if the gating scan found HIGH/CRITICAL — the SBOM is a
+              # static inventory and should be produced regardless of gating.
+              if: ${{ !cancelled() }}
+              uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+              with:
+                  version: v0.71.1
+                  scan-type: fs
+                  scan-ref: .
+                  format: cyclonedx
+                  output: sbom.cdx.json
+                  cache: "true"
+
+            - name: Upload SBOM artifact
+              if: ${{ !cancelled() }}
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: sbom-cyclonedx
+                  path: sbom.cdx.json
+                  retention-days: 90
+
+    govulncheck:
+        # Go-native reachability gate, complementary to Trivy's SCA scan. It
+        # fails only when a vulnerable symbol is actually reachable from this
+        # module's code (call-graph analysis against https://vuln.go.dev plus the
+        # stdlib for the toolchain in use), keeping the gate low-noise while still
+        # catching exploitable stdlib CVEs that a version-range scan misses. The
+        # advisory DB is fetched fresh each run.
+        name: Security scan (govulncheck)
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+            - name: Set up Go
+              uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+              with:
+                  go-version-file: go.mod
+                  check-latest: true
+
+            - name: Run govulncheck
+              # Pin the binary so a release can't silently change scan behavior.
+              # Installed via `go install` (not in go.mod, so out of the module
+              # graph + SBOM) — bump by hand after reviewing
+              # https://github.com/golang/vuln/releases. Exit code 3 (a vuln in
+              # CALLED code) fails the job; imported-but-uncalled findings don't.
+              run: |
+                  go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+                  govulncheck ./...
+
+            - name: govulncheck JSON report (non-gating)
+              # Re-run in JSON purely to feed the PR summary; never gates (|| true).
+              # The text run above stays the authoritative gate. Invoked by
+              # absolute path in case GOPATH/bin isn't on PATH for this step.
+              if: ${{ !cancelled() }}
+              run: |
+                  GOVULNCHECK="$(go env GOPATH)/bin/govulncheck"
+                  "$GOVULNCHECK" -format json ./... > govulncheck.json || true
+
+            - name: Upload govulncheck JSON report
+              if: ${{ !cancelled() }}
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: govulncheck-json
+                  path: govulncheck.json
+                  retention-days: 90
+
+    security-report:
+        # Consolidates every security scan into ONE Markdown report, posted as a
+        # sticky PR comment (the visibility goal), the run's job summary, and the
+        # `security-summary` artifact. REPORTING ONLY — it never gates. Per-scan
+        # pass/fail is taken verbatim from the gate jobs (needs.*.result), so a
+        # green comment can never mask a red gate.
+        name: Security scan summary
+        needs: [security, govulncheck]
+        # Run even when a gate above failed — that's when the summary matters most.
+        if: ${{ !cancelled() }}
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read # checkout + read go.mod for the dependency overview
+            pull-requests: write # post/update the sticky summary comment
+            security-events: read # read open CodeQL alerts to enrich the summary
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+            - name: Download scan artifacts
+              uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+              with:
+                  path: scan-artifacts
+                  merge-multiple: true
+
+            - name: Fetch open CodeQL alerts (best effort)
+              # The CodeQL workflow (codeql.yml) runs separately; its open alerts
+              # for this ref are pulled via the API only to enrich the summary.
+              # Never fails the job — a not-yet-complete analysis just yields [].
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  gh api "repos/${GITHUB_REPOSITORY}/code-scanning/alerts?ref=${GITHUB_REF}&state=open&per_page=100" \
+                      > scan-artifacts/codeql-alerts.json 2>/dev/null || echo '[]' > scan-artifacts/codeql-alerts.json
+
+            - name: Build security summary
+              env:
+                  SECURITY_RESULT: ${{ needs.security.result }}
+                  GOVULNCHECK_RESULT: ${{ needs.govulncheck.result }}
+                  COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+                  BRANCH: ${{ github.head_ref || github.ref_name }}
+              run: |
+                  bash scripts/security-summary.sh \
+                      scan-artifacts/trivy-results.json \
+                      scan-artifacts/govulncheck.json \
+                      scan-artifacts/sbom.cdx.json \
+                      go.mod \
+                      scan-artifacts/codeql-alerts.json \
+                      > security-summary.md
+                  cat security-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Upload summary artifact
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: security-summary
+                  path: security-summary.md
+                  retention-days: 90
+
+            - name: Post or update PR comment
+              # Only for PRs from a branch in THIS repo. Fork PRs get a read-only
+              # GITHUB_TOKEN (commenting would 403), so skip them — the job
+              # summary + artifact above are still produced. A sticky marker keeps
+              # it to one comment that updates in place instead of one per push.
+              if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+              run: |
+                  set -uo pipefail
+                  marker='<!-- security-scan-summary -->'
+                  existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
+                                --jq "map(select(.body | startswith(\"${marker}\"))) | .[0].id // empty")"
+                  jq -Rs '{body: .}' security-summary.md > comment-payload.json
+                  if [ -n "${existing}" ]; then
+                      gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" \
+                          --input comment-payload.json >/dev/null
+                      echo "Updated existing summary comment #${existing} on PR #${PR_NUMBER}."
+                  else
+                      gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+                          --input comment-payload.json >/dev/null
+                      echo "Posted new summary comment on PR #${PR_NUMBER}."
+                  fi
+
     acceptance:
         name: Acceptance Tests
         needs: check

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,3 +24,37 @@ vulnerabilities in the Spaceship platform or API, please contact
 
 Security fixes are applied to the latest release only. We recommend always
 using the most recent version of the provider.
+
+## Automated Security Scanning
+
+Every push and pull request runs a set of security gates in
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml):
+
+- **Trivy** (`security` job) — vulnerability (SCA), IaC misconfiguration,
+  secret, and license scanning. The gate blocks merge on `CRITICAL,HIGH`
+  findings with an available fix (`ignore-unfixed: true`). The license denylist
+  lives in [`trivy.yaml`](trivy.yaml) (copyleft / source-available licenses we
+  cannot ship). A CycloneDX SBOM is generated and uploaded as the
+  `sbom-cyclonedx` artifact.
+- **govulncheck** (`govulncheck` job) — Go-native call-graph **reachability**
+  analysis against <https://vuln.go.dev> and the standard library. Fails the
+  build only when a vulnerable symbol is actually reachable from the provider's
+  code; imported-but-uncalled vulnerabilities are reported but do not gate.
+- **CodeQL** ([`codeql.yml`](.github/workflows/codeql.yml)) — static analysis
+  with the `security-and-quality` query suite.
+
+### PR security summary
+
+The `security-report` job consolidates all of the above into a single Markdown
+report, surfaced three ways: a **sticky pull-request comment** (one comment,
+updated in place per push), the run's **job summary**, and the
+**`security-summary`** workflow artifact. It reports Trivy findings by severity,
+govulncheck reachable-vs-imported counts, open CodeQL alerts, and a dependency
+overview (SBOM component count, `go.mod` direct/indirect split, license
+breakdown).
+
+The summary is **reporting only and never gates** — the per-scan pass/fail it
+shows is taken verbatim from the gate jobs above, so a green comment can never
+mask a red gate. Secret findings list the rule and location only, never the
+matched value. The comment is skipped for pull requests from forks (whose token
+is read-only); the job summary and artifact are still produced.

--- a/scripts/security-summary.sh
+++ b/scripts/security-summary.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Render a consolidated security-scan summary (GitHub-flavored Markdown) from the
+# JSON outputs of the CI security jobs. Consumed by the `security-report` job in
+# .github/workflows/ci.yml: written to the run's job summary, uploaded as the
+# `security-summary` artifact, and posted as a sticky PR comment.
+#
+# Usage:
+#   security-summary.sh TRIVY_JSON GOVULN_JSON SBOM_JSON GO_MOD CODEQL_JSON
+#
+# Every input is best-effort: a missing, empty, or unparseable file degrades
+# that section gracefully rather than failing. This script is REPORTING ONLY and
+# never exits non-zero on scan content — the merge gates live in the scan jobs.
+# Pass/fail shown in the status table comes from the gate jobs' results
+# (SECURITY_RESULT / GOVULNCHECK_RESULT env), not from re-deriving it here.
+set -uo pipefail
+
+TRIVY="${1:-}"
+GOVULN="${2:-}"
+SBOM="${3:-}"
+GOMOD="${4:-go.mod}"
+CODEQL="${5:-}"
+
+MARKER='<!-- security-scan-summary -->'
+SHA_SHORT="${COMMIT_SHA:0:8}"
+BRANCH="${BRANCH:-unknown}"
+NOW="$(date -u '+%Y-%m-%d %H:%M UTC')"
+
+# jq wrapper: print the filter result, or a fallback when the file is
+# missing/empty/invalid, so one dead scan job can't break the whole report.
+# Args: <file> <filter> <fallback> [slurp-flag e.g. -s]
+jqf() {
+  local file="$1" filter="$2" fallback="$3" slurp="${4:-}"
+  if [ -s "$file" ]; then
+    jq ${slurp} -r "$filter" "$file" 2>/dev/null || printf '%s' "$fallback"
+  else
+    printf '%s' "$fallback"
+  fi
+}
+
+# success -> check, failure -> cross, anything else (skipped/unknown) -> circle
+emoji() {
+  case "$1" in
+    success) printf '✅' ;;
+    failure) printf '❌' ;;
+    *) printf '⚪' ;;
+  esac
+}
+
+# --- Trivy counts ----------------------------------------------------------
+tv_crit=$(jqf "$TRIVY" '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' 0)
+tv_high=$(jqf "$TRIVY" '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH")]     | length' 0)
+tv_med=$(jqf  "$TRIVY" '[.Results[]?.Vulnerabilities[]? | select(.Severity=="MEDIUM")]   | length' 0)
+tv_low=$(jqf  "$TRIVY" '[.Results[]?.Vulnerabilities[]? | select(.Severity=="LOW")]      | length' 0)
+tv_unkn=$(jqf "$TRIVY" '[.Results[]?.Vulnerabilities[]? | select(.Severity=="UNKNOWN")]  | length' 0)
+tv_misconf=$(jqf "$TRIVY" '[.Results[]?.Misconfigurations[]? | select(.Status=="FAIL")] | length' 0)
+tv_secrets=$(jqf "$TRIVY" '[.Results[]?.Secrets[]?] | length' 0)
+tv_lic=$(jqf "$TRIVY" '[.Results[]?.Licenses[]?] | length' 0)
+
+# --- govulncheck counts (NDJSON stream -> slurp) ---------------------------
+gv_reach=$(jqf "$GOVULN" '[.[] | select(.finding!=null) | .finding | select(.trace[0].function!=null) | .osv] | unique | length' 0 -s)
+gv_total=$(jqf "$GOVULN" '[.[] | select(.finding!=null) | .finding.osv] | unique | length' 0 -s)
+gv_imported=$(( gv_total - gv_reach ))
+[ "$gv_imported" -lt 0 ] && gv_imported=0
+
+# --- SBOM / dependency overview --------------------------------------------
+sbom_comp=$(jqf "$SBOM" '[.components[]?] | length' 0)
+read -r mod_direct mod_indirect < <(awk '
+  /^require[[:space:]]*\(/ { inblk=1; next }
+  inblk && /^\)/ { inblk=0; next }
+  /^require[[:space:]]+[^(]/ { if ($0 ~ /\/\/[[:space:]]*indirect/) ind++; else dir++; next }
+  inblk && NF>=2 && $1!="//" { if ($0 ~ /\/\/[[:space:]]*indirect/) ind++; else dir++ }
+  END { printf "%d %d", dir+0, ind+0 }
+' "$GOMOD" 2>/dev/null || echo "0 0")
+
+# --- CodeQL (code scanning) open alerts ------------------------------------
+cq_total=$(jqf "$CODEQL" 'if type=="array" then length else 0 end' 0)
+cq_crit=$(jqf "$CODEQL"  'if type=="array" then [.[]|select(.rule.security_severity_level=="critical")]|length else 0 end' 0)
+cq_high=$(jqf "$CODEQL"  'if type=="array" then [.[]|select(.rule.security_severity_level=="high")]|length else 0 end' 0)
+
+# --- status from the actual gate jobs --------------------------------------
+trivy_status=$(emoji "${SECURITY_RESULT:-}")
+govuln_status=$(emoji "${GOVULNCHECK_RESULT:-}")
+
+# ===========================================================================
+# Markdown. First line is the sticky marker so the workflow can find + update
+# this exact comment instead of posting a new one each push.
+# ===========================================================================
+printf '%s\n' "$MARKER"
+printf '## 🔐 Security scan summary\n\n'
+printf '_Commit `%s` · branch `%s` · generated %s_\n\n' "$SHA_SHORT" "$BRANCH" "$NOW"
+
+printf '| Scan | Gate | Findings |\n'
+printf '|---|:---:|---|\n'
+printf '| **Trivy — vulnerabilities** (SCA) | %s | 🔴 %s critical · 🟠 %s high · 🟡 %s medium · ⚪ %s low · %s unknown |\n' \
+  "$trivy_status" "$tv_crit" "$tv_high" "$tv_med" "$tv_low" "$tv_unkn"
+printf '| **Trivy — IaC misconfig** | %s | %s failing |\n' "$trivy_status" "$tv_misconf"
+printf '| **Trivy — secrets** | %s | %s detected |\n' "$trivy_status" "$tv_secrets"
+printf '| **Trivy — licenses** | %s | %s policy finding(s) |\n' "$trivy_status" "$tv_lic"
+printf '| **govulncheck** (reachability) | %s | %s reachable · %s imported-only |\n' \
+  "$govuln_status" "$gv_reach" "$gv_imported"
+printf '| **CodeQL** (code scanning, open) | — | %s open · 🔴 %s critical · 🟠 %s high |\n' \
+  "$cq_total" "$cq_crit" "$cq_high"
+printf '\n'
+printf '> **Gate** (blocks merge): HIGH/CRITICAL **fixable** CVEs · reachable Go vulnerabilities · forbidden licenses · committed secrets. '
+printf 'Counts above are the *full* picture (incl. medium/low and unfixed), so they can exceed what actually gates. '
+printf 'CodeQL is informational here. ✅ = gate job passed, ❌ = failed, ⚪ = skipped.\n\n'
+
+# --- dependency overview ---------------------------------------------------
+printf '### 📦 Dependencies\n\n'
+printf -- '- **SBOM components (CycloneDX):** %s\n' "$sbom_comp"
+printf -- '- **Go modules in `go.mod`:** %s direct · %s indirect\n\n' "$mod_direct" "$mod_indirect"
+
+lic_breakdown=$(jqf "$SBOM" '
+  [.components[]?.licenses[]? | (.license.id // .license.name // .expression // "UNKNOWN")]
+  | group_by(.) | map({k: .[0], n: length}) | sort_by(-.n) | .[:10][]
+  | "| \(.k) | \(.n) |"' "")
+if [ -n "$lic_breakdown" ]; then
+  printf '<details><summary>License breakdown (top 10)</summary>\n\n'
+  printf '| License | Components |\n|---|---:|\n%s\n\n</details>\n\n' "$lic_breakdown"
+fi
+
+# --- detail sections (only when there is something to show) ----------------
+vuln_rows=$(jqf "$TRIVY" '
+  [.Results[]?.Vulnerabilities[]?]
+  | unique_by([.VulnerabilityID, .PkgName])
+  | sort_by({"CRITICAL":0,"HIGH":1,"MEDIUM":2,"LOW":3,"UNKNOWN":4}[.Severity] // 5)
+  | .[:50][]
+  | "| \(.Severity) | \(.VulnerabilityID) | \(.PkgName) | \(.InstalledVersion) | \((.FixedVersion // "") | if . == "" then "—" else . end) |"' "")
+if [ -n "$vuln_rows" ]; then
+  printf '<details><summary>Vulnerabilities (Trivy, top 50)</summary>\n\n'
+  printf '| Severity | ID | Package | Installed | Fixed |\n|---|---|---|---|---|\n%s\n\n</details>\n\n' "$vuln_rows"
+fi
+
+gv_rows=$(jqf "$GOVULN" '
+  [.[] | select(.finding!=null) | .finding | select(.trace[0].function!=null)
+   | {osv, module: .trace[0].module, fn: .trace[0].function}]
+  | unique_by(.osv) | .[]
+  | "| \(.osv) | \(.module // "—") | `\(.fn // "—")` |"' "" -s)
+if [ -n "$gv_rows" ]; then
+  printf '<details><summary>Reachable Go vulnerabilities (govulncheck)</summary>\n\n'
+  printf '| Advisory | Module | Called symbol |\n|---|---|---|\n%s\n\n</details>\n\n' "$gv_rows"
+fi
+
+lic_rows=$(jqf "$TRIVY" '
+  [.Results[]?.Licenses[]?] | .[]
+  | "| \(.Severity) | \(.PkgName // .FilePath // "—") | \(.Name) | \(.Category // "—") |"' "")
+if [ -n "$lic_rows" ]; then
+  printf '<details><summary>License findings (Trivy)</summary>\n\n'
+  printf '| Severity | Package/File | License | Category |\n|---|---|---|---|\n%s\n\n</details>\n\n' "$lic_rows"
+fi
+
+misconf_rows=$(jqf "$TRIVY" '
+  [.Results[]? | .Target as $t | (.Misconfigurations[]? | select(.Status=="FAIL") | {t: $t, id: .ID, sev: .Severity, title: .Title})]
+  | .[] | "| \(.sev) | \(.id) | \(.title) | \(.t) |"' "")
+if [ -n "$misconf_rows" ]; then
+  printf '<details><summary>IaC misconfigurations (Trivy)</summary>\n\n'
+  printf '| Severity | ID | Title | Target |\n|---|---|---|---|\n%s\n\n</details>\n\n' "$misconf_rows"
+fi
+
+# Secrets: report rule + location only, NEVER the matched value, to avoid
+# re-leaking a credential into the PR comment / artifact.
+secret_rows=$(jqf "$TRIVY" '
+  [.Results[]? | .Target as $t | (.Secrets[]? | {t: $t, rule: .RuleID, sev: .Severity, title: .Title, line: .StartLine})]
+  | .[] | "| \(.sev) | \(.rule) | \(.title) | \(.t):\(.line) |"' "")
+if [ -n "$secret_rows" ]; then
+  printf '<details><summary>Secret findings (Trivy — values redacted)</summary>\n\n'
+  printf '| Severity | Rule | Title | Location |\n|---|---|---|---|\n%s\n\n</details>\n\n' "$secret_rows"
+fi
+
+printf -- '---\n'
+printf '📎 Full machine-readable reports are attached to this run as artifacts: '
+printf '`security-summary`, `trivy-json`, `govulncheck-json`, `sbom-cyclonedx`.\n'

--- a/scripts/security-summary.sh
+++ b/scripts/security-summary.sh
@@ -21,9 +21,25 @@ GOMOD="${4:-go.mod}"
 CODEQL="${5:-}"
 
 MARKER='<!-- security-scan-summary -->'
-SHA_SHORT="${COMMIT_SHA:0:8}"
+# Guard before substring: under `set -u` ${COMMIT_SHA:0:8} on an unset var is a
+# fatal unbound-variable error, and an empty COMMIT_SHA would render empty
+# backticks. Fall back to "unknown" for both, mirroring BRANCH below.
+_sha="${COMMIT_SHA:-unknown}"
+SHA_SHORT="${_sha:0:8}"
 BRANCH="${BRANCH:-unknown}"
+# Sanitize the shell-interpolated branch before it lands inside a backtick span
+# on the commit line: collapse newlines/CR/pipes to spaces and drop backticks so
+# the value can't escape the inline-code span (mirrors the jq `cell` helper).
+BRANCH="$(printf '%s' "$BRANCH" | tr '\n\r|' '   ' | tr -d '`')"
 NOW="$(date -u '+%Y-%m-%d %H:%M UTC')"
+
+# Reusable jq helper: sanitize an untrusted string for a Markdown table cell.
+# Coerces to string, escapes the column separator (| -> \|), collapses any
+# newline/CR to a space (a raw newline would split the row), and strips
+# backticks so a value can't break out of (or forge) an inline-code span.
+# Prepend $CELL to any filter that interpolates scan/dep data, then pipe each
+# untrusted field through `| cell`.
+CELL='def cell: (. // "") | tostring | gsub("\r";" ") | gsub("\n";" ") | gsub("[|]";"\\|") | gsub("`";"");'
 
 # jq wrapper: print the filter result, or a fallback when the file is
 # missing/empty/invalid, so one dead scan job can't break the whole report.
@@ -110,48 +126,48 @@ printf '### 📦 Dependencies\n\n'
 printf -- '- **SBOM components (CycloneDX):** %s\n' "$sbom_comp"
 printf -- '- **Go modules in `go.mod`:** %s direct · %s indirect\n\n' "$mod_direct" "$mod_indirect"
 
-lic_breakdown=$(jqf "$SBOM" '
+lic_breakdown=$(jqf "$SBOM" "$CELL"'
   [.components[]?.licenses[]? | (.license.id // .license.name // .expression // "UNKNOWN")]
   | group_by(.) | map({k: .[0], n: length}) | sort_by(-.n) | .[:10][]
-  | "| \(.k) | \(.n) |"' "")
+  | "| \(.k | cell) | \(.n) |"' "")
 if [ -n "$lic_breakdown" ]; then
   printf '<details><summary>License breakdown (top 10)</summary>\n\n'
   printf '| License | Components |\n|---|---:|\n%s\n\n</details>\n\n' "$lic_breakdown"
 fi
 
 # --- detail sections (only when there is something to show) ----------------
-vuln_rows=$(jqf "$TRIVY" '
+vuln_rows=$(jqf "$TRIVY" "$CELL"'
   [.Results[]?.Vulnerabilities[]?]
   | unique_by([.VulnerabilityID, .PkgName])
   | sort_by({"CRITICAL":0,"HIGH":1,"MEDIUM":2,"LOW":3,"UNKNOWN":4}[.Severity] // 5)
   | .[:50][]
-  | "| \(.Severity) | \(.VulnerabilityID) | \(.PkgName) | \(.InstalledVersion) | \((.FixedVersion // "") | if . == "" then "—" else . end) |"' "")
+  | "| \(.Severity | cell) | \(.VulnerabilityID | cell) | \(.PkgName | cell) | \(.InstalledVersion | cell) | \((.FixedVersion // "") | if . == "" then "—" else . end | cell) |"' "")
 if [ -n "$vuln_rows" ]; then
   printf '<details><summary>Vulnerabilities (Trivy, top 50)</summary>\n\n'
   printf '| Severity | ID | Package | Installed | Fixed |\n|---|---|---|---|---|\n%s\n\n</details>\n\n' "$vuln_rows"
 fi
 
-gv_rows=$(jqf "$GOVULN" '
+gv_rows=$(jqf "$GOVULN" "$CELL"'
   [.[] | select(.finding!=null) | .finding | select(.trace[0].function!=null)
    | {osv, module: .trace[0].module, fn: .trace[0].function}]
   | unique_by(.osv) | .[]
-  | "| \(.osv) | \(.module // "—") | `\(.fn // "—")` |"' "" -s)
+  | "| \(.osv | cell) | \(.module // "—" | cell) | `\(.fn // "—" | cell)` |"' "" -s)
 if [ -n "$gv_rows" ]; then
   printf '<details><summary>Reachable Go vulnerabilities (govulncheck)</summary>\n\n'
   printf '| Advisory | Module | Called symbol |\n|---|---|---|\n%s\n\n</details>\n\n' "$gv_rows"
 fi
 
-lic_rows=$(jqf "$TRIVY" '
+lic_rows=$(jqf "$TRIVY" "$CELL"'
   [.Results[]?.Licenses[]?] | .[]
-  | "| \(.Severity) | \(.PkgName // .FilePath // "—") | \(.Name) | \(.Category // "—") |"' "")
+  | "| \(.Severity | cell) | \(.PkgName // .FilePath // "—" | cell) | \(.Name | cell) | \(.Category // "—" | cell) |"' "")
 if [ -n "$lic_rows" ]; then
   printf '<details><summary>License findings (Trivy)</summary>\n\n'
   printf '| Severity | Package/File | License | Category |\n|---|---|---|---|\n%s\n\n</details>\n\n' "$lic_rows"
 fi
 
-misconf_rows=$(jqf "$TRIVY" '
+misconf_rows=$(jqf "$TRIVY" "$CELL"'
   [.Results[]? | .Target as $t | (.Misconfigurations[]? | select(.Status=="FAIL") | {t: $t, id: .ID, sev: .Severity, title: .Title})]
-  | .[] | "| \(.sev) | \(.id) | \(.title) | \(.t) |"' "")
+  | .[] | "| \(.sev | cell) | \(.id | cell) | \(.title | cell) | \(.t | cell) |"' "")
 if [ -n "$misconf_rows" ]; then
   printf '<details><summary>IaC misconfigurations (Trivy)</summary>\n\n'
   printf '| Severity | ID | Title | Target |\n|---|---|---|---|\n%s\n\n</details>\n\n' "$misconf_rows"
@@ -159,9 +175,9 @@ fi
 
 # Secrets: report rule + location only, NEVER the matched value, to avoid
 # re-leaking a credential into the PR comment / artifact.
-secret_rows=$(jqf "$TRIVY" '
+secret_rows=$(jqf "$TRIVY" "$CELL"'
   [.Results[]? | .Target as $t | (.Secrets[]? | {t: $t, rule: .RuleID, sev: .Severity, title: .Title, line: .StartLine})]
-  | .[] | "| \(.sev) | \(.rule) | \(.title) | \(.t):\(.line) |"' "")
+  | .[] | "| \(.sev | cell) | \(.rule | cell) | \(.title | cell) | \(.t | cell):\(.line) |"' "")
 if [ -n "$secret_rows" ]; then
   printf '<details><summary>Secret findings (Trivy — values redacted)</summary>\n\n'
   printf '| Severity | Rule | Title | Location |\n|---|---|---|---|\n%s\n\n</details>\n\n' "$secret_rows"

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,20 @@
+# Trivy policy file — auto-loaded from repo root by `trivy fs`.
+# Applied to every CI run of the `security` job in .github/workflows/ci.yml.
+#
+# License policy: denylist the copyleft and source-available licenses we
+# cannot ship in a Terraform provider distributed via the public registry.
+# Everything else is permitted — enumerating a permissive allowlist is a
+# losing battle because new permissive licenses land each year and don't
+# need review to keep CI green.
+#
+# To request an exception, open a PR that adds a scoped `ignored-licenses:`
+# entry covering the specific package + license combination, with a
+# justification and a reviewer from outside the requesting team.
+license:
+  forbidden:
+    - GPL-2.0
+    - GPL-3.0
+    - AGPL-1.0
+    - AGPL-3.0
+    - LGPL-3.0
+    - SSPL-1.0


### PR DESCRIPTION
## What

Brings this provider's CI in line with [terraform-provider-namecheap#234](https://github.com/namecheap/terraform-provider-namecheap/pull/234): adds the full security-scan stack **and** a single consolidated report posted to every PR.

Surfaced three ways:

- 💬 **Sticky PR comment** — one comment, updated in place per push (marker `<!-- security-scan-summary -->`).
- 🧾 **Job summary** — rendered on the Actions run page.
- 📎 **`security-summary` artifact** — 90-day retention.

## New CI jobs (`.github/workflows/ci.yml`)

| Job | What it does |
|---|---|
| `security` | Trivy fs scan — **vuln + misconfig + secret + license**. Gates on CRITICAL/HIGH *fixable*. License denylist in `trivy.yaml`. Emits CycloneDX SBOM (`sbom-cyclonedx`) + a non-gating JSON pass (`trivy-json`). |
| `govulncheck` | Go-native **reachability** gate (vuln in *called* code fails). Non-gating JSON pass (`govulncheck-json`). |
| `security-report` | Consolidates Trivy + govulncheck + SBOM + open CodeQL alerts into the Markdown report; writes job summary, uploads `security-summary`, posts/updates the sticky comment. |

Report covers: Trivy findings by severity, IaC misconfig, secrets (rule/location only — **never the value**), licenses; govulncheck reachable-vs-imported; open CodeQL alerts (from the existing `codeql.yml`); and a dependency overview (SBOM component count, `go.mod` direct/indirect, license breakdown).

## Design notes

- **Reporting only — never gates.** Per-scan ✅/❌ comes verbatim from the gate jobs' `needs.*.result`, so a green comment can't mask a red gate. The `security` and `govulncheck` jobs are the actual merge gates.
- **PR association:** uses the `pull_request` event number directly (this workflow already triggers on `pull_request`). The comment step is restricted to same-repo branches — **fork PRs skip the comment** (their `GITHUB_TOKEN` is read-only) but still get the job summary + artifact.
- Matches this repo's conventions: 4-space YAML, existing action pins reused (`checkout@v5.0.1`, `setup-go@v6.4.0`, `upload-artifact@v6.0.0`); new `download-artifact` SHA-pinned to `v6.0.0`. Go version via `go-version-file: go.mod`.
- New `trivy.yaml` (license denylist) and `scripts/security-summary.sh` (the generator) are shared verbatim with the namecheap provider. Verified locally: YAML parses, `bash -n`, and the generator against this repo's real `go.mod` (7 direct · 51 indirect) plus fully-degraded inputs.

Documented under **Automated Security Scanning** in `SECURITY.md`.