### PR TITLE
fix(client): paginate domain list

### DIFF
--- a/internal/client/domains.go
+++ b/internal/client/domains.go
@@ -7,7 +7,8 @@ import (
 	"strconv"
 )
 
-// DomainList is a page of domains returned by the domain list endpoint.
+// DomainList holds domains returned by the domain list endpoint. GetDomainList
+// returns one with every domain in the account, accumulated across all pages.
 type DomainList struct {
 	Items []DomainInfo `json:"items"`
 	Total int64        `json:"total"`

--- a/internal/client/domains.go
+++ b/internal/client/domains.go
@@ -7,10 +7,14 @@ import (
 	"strconv"
 )
 
+// DomainList is a page of domains returned by the domain list endpoint.
 type DomainList struct {
 	Items []DomainInfo `json:"items"`
 	Total int64        `json:"total"`
 }
+
+// DomainInfo describes a single domain: registration state, lifecycle and
+// verification status, privacy settings, nameservers, and contacts.
 type DomainInfo struct {
 	Name               string            `json:"name"`
 	UnicodeName        string            `json:"unicodeName"`
@@ -27,20 +31,24 @@ type DomainInfo struct {
 	Contacts           Contacts          `json:"contacts"`
 }
 
+// ReasonCode is a single suspension reason attached to a domain.
 type ReasonCode struct {
 	ReasonCode string `json:"reasonCode"`
 }
 
+// PrivacyProtection describes a domain's WHOIS privacy configuration.
 type PrivacyProtection struct {
 	ContactForm bool   `json:"contactForm"`
 	Level       string `json:"level"`
 }
 
+// Nameservers describes a domain's nameserver provider and host list.
 type Nameservers struct {
 	Provider string   `json:"provider"`
 	Hosts    []string `json:"hosts"`
 }
 
+// Contacts holds the contact handle IDs associated with a domain.
 type Contacts struct {
 	Registrant string   `json:"registrant"`
 	Admin      string   `json:"admin"`
@@ -97,14 +105,17 @@ func (c *Client) listDomains(ctx context.Context, pageSize int) (DomainList, err
 	return result, nil
 }
 
+// GetDomainInfo fetches details for a single domain.
+//
+// The dedicated domain-info endpoint is aggressively rate limited. On HTTP 429
+// this falls back to the domain list endpoint, which exposes the same data with
+// far higher limits, and returns the matching entry if present.
 func (c *Client) GetDomainInfo(ctx context.Context, domain string) (DomainInfo, error) {
 	var domainInfo DomainInfo
 
 	endpoint := c.endpointURL([]string{"domains", domain}, nil)
 
-	// overcome insane API rate limiting
-	// by using alternative endpoint that does the same
-	// but has 60x times higher limits
+	// On 429, fall back to the higher-limit domain list endpoint.
 	statusCode, err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &domainInfo)
 	if statusCode == http.StatusTooManyRequests {
 		domainList, _ := c.GetDomainList(ctx)
@@ -123,6 +134,8 @@ func (c *Client) GetDomainInfo(ctx context.Context, domain string) (DomainInfo, 
 	return domainInfo, nil
 }
 
+// findDomainByNameFromDomainList returns the domain entry matching name
+// (exact match) and whether it was found.
 func findDomainByNameFromDomainList(dl DomainList, domain string) (DomainInfo, bool) {
 	for _, domainItem := range dl.Items {
 		if domainItem.Name == domain {
@@ -132,10 +145,13 @@ func findDomainByNameFromDomainList(dl DomainList, domain string) (DomainInfo, b
 	return DomainInfo{}, false
 }
 
+// AutoRenewalResponse is the response from the auto-renew toggle endpoint.
 type AutoRenewalResponse struct {
 	IsEnabled bool `json:"isEnabled"`
 }
 
+// UpdateAutoRenew enables or disables auto-renewal for the domain and returns
+// the resulting state.
 func (c *Client) UpdateAutoRenew(ctx context.Context, domain string, value bool) (AutoRenewalResponse, error) {
 	var resp AutoRenewalResponse
 
@@ -156,22 +172,30 @@ func (c *Client) UpdateAutoRenew(ctx context.Context, domain string, value bool)
 
 }
 
+// NameserverProvider selects which nameservers a domain uses: Spaceship's
+// "basic" set or a caller-supplied "custom" host list.
 type NameserverProvider string
 
 const (
+	// BasicNameserverProvider uses Spaceship's default nameservers; Hosts must be empty.
 	BasicNameserverProvider NameserverProvider = "basic"
-	CustomNameserverProvider  NameserverProvider = "custom"
+	// CustomNameserverProvider uses a caller-supplied Hosts list.
+	CustomNameserverProvider NameserverProvider = "custom"
 )
 
+// Valid reports whether p is one of the recognized provider values.
 func (p NameserverProvider) Valid() bool {
 	return p == BasicNameserverProvider || p == CustomNameserverProvider
 }
 
+// UpdateNameserverRequest is the input to UpdateDomainNameServers. When Provider
+// is basic, Hosts must be empty; when custom, Hosts lists the nameserver hostnames.
 type UpdateNameserverRequest struct {
 	Provider NameserverProvider
 	Hosts    []string
 }
 
+// DefaultBasicNameserverHosts returns Spaceship's default "basic" nameserver hosts.
 func DefaultBasicNameserverHosts() []string {
 	return []string{"launch1.spaceship.net", "launch2.spaceship.net"}
 }

--- a/internal/client/domains.go
+++ b/internal/client/domains.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"strconv"
 )
 
 type DomainList struct {
@@ -48,23 +49,52 @@ type Contacts struct {
 	Attributes []string `json:"attributes"`
 }
 
-// TODO
-// create pagination later when there are more than 100 domains in account
+const maxDomainListPageSize = 100
+
+// GetDomainList fetches all domains in the account, following pagination until
+// every page has been retrieved.
 func (c *Client) GetDomainList(ctx context.Context) (DomainList, error) {
-	var domainList DomainList
+	return c.listDomains(ctx, maxDomainListPageSize)
+}
 
-	query := url.Values{}
-	query.Set("take", "100")
-	query.Set("skip", "0")
-	query.Set("orderBy", "name")
+// listDomains fetches all domains using the given page size, following
+// pagination. The page size is a parameter so tests can force multi-page
+// behavior against accounts with only a handful of domains; production callers
+// use GetDomainList, which passes the API maximum (100).
+func (c *Client) listDomains(ctx context.Context, pageSize int) (DomainList, error) {
+	var (
+		result DomainList
+		skip   = 0
+		total  = int64(-1)
+	)
 
-	endpoint := c.endpointURL([]string{"domains"}, query)
+	for {
+		query := url.Values{}
+		query.Set("take", strconv.Itoa(pageSize))
+		query.Set("skip", strconv.Itoa(skip))
+		query.Set("orderBy", "name")
 
-	if _, err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &domainList); err != nil {
-		return domainList, err
+		endpoint := c.endpointURL([]string{"domains"}, query)
+
+		var page DomainList
+		if _, err := c.doJSON(ctx, http.MethodGet, endpoint, nil, &page); err != nil {
+			return DomainList{}, err
+		}
+
+		result.Items = append(result.Items, page.Items...)
+
+		if total == -1 {
+			total = page.Total
+		}
+		if int64(len(result.Items)) >= total || len(page.Items) == 0 {
+			break
+		}
+
+		skip += pageSize
 	}
 
-	return domainList, nil
+	result.Total = total
+	return result, nil
 }
 
 func (c *Client) GetDomainInfo(ctx context.Context, domain string) (DomainInfo, error) {

--- a/internal/client/domains.go
+++ b/internal/client/domains.go
@@ -160,11 +160,11 @@ type NameserverProvider string
 
 const (
 	BasicNameserverProvider NameserverProvider = "basic"
-	CustomNamerverProvider  NameserverProvider = "custom"
+	CustomNameserverProvider  NameserverProvider = "custom"
 )
 
 func (p NameserverProvider) Valid() bool {
-	return p == BasicNameserverProvider || p == CustomNamerverProvider
+	return p == BasicNameserverProvider || p == CustomNameserverProvider
 }
 
 type UpdateNameserverRequest struct {
@@ -179,7 +179,7 @@ func DefaultBasicNameserverHosts() []string {
 /*
 UpdateDomainNameServers updates the nameserver configuration for a domain.
 The request Provider must be one of BasicNameserverProvider or
-CustomNamerverProvider. When Provider is basic, Hosts must be empty and the
+CustomNameserverProvider. When Provider is basic, Hosts must be empty and the
 default Spaceship nameservers are used. When Provider is custom, Hosts must
 contain the desired nameserver hostnames.
 

--- a/internal/client/domains_acc_test.go
+++ b/internal/client/domains_acc_test.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"os"
+	"testing"
+)
+
+// Live check against the real Spaceship API. Forces pagination with a page size
+// of 1 and asserts it returns the same domains as a single large page, so it
+// proves the loop reassembles the full list on any account with >= 2 domains —
+// no need to own 100. Skipped unless API credentials are set, and excluded from
+// `make test` by the TestAcc prefix.
+func TestAccGetDomainListPagination(t *testing.T) {
+	key := os.Getenv("SPACESHIP_API_KEY")
+	secret := os.Getenv("SPACESHIP_API_SECRET")
+	if key == "" || secret == "" {
+		t.Skip("set SPACESHIP_API_KEY and SPACESHIP_API_SECRET to run the live pagination check")
+	}
+
+	c, err := NewClient("https://spaceship.dev/api/v1", key, secret)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	full, err := c.listDomains(t.Context(), maxDomainListPageSize)
+	if err != nil {
+		t.Fatalf("single-page list (take=100): %v", err)
+	}
+
+	paged, err := c.listDomains(t.Context(), 1)
+	if err != nil {
+		t.Fatalf("paged list (take=1): %v", err)
+	}
+
+	// Same set regardless of page size.
+	if len(paged.Items) != len(full.Items) {
+		t.Fatalf("pagination mismatch: take=1 returned %d domains, take=100 returned %d",
+			len(paged.Items), len(full.Items))
+	}
+
+	// The loop's termination invariant: the API's reported total must equal the
+	// number of items actually collected. If total were a per-page count, the
+	// loop would either stop early or spin — this asserts it is the global count.
+	if full.Total != int64(len(full.Items)) {
+		t.Fatalf("total invariant broken: API total=%d but collected %d items",
+			full.Total, len(full.Items))
+	}
+
+	switch {
+	case len(full.Items) >= 2:
+		t.Logf("pagination exercised across multiple pages: %d domains via take=1", len(full.Items))
+	default:
+		t.Logf("contract confirmed (take/skip/total/orderBy) but only %d domain in account; "+
+			"multi-page iteration NOT exercised — needs >= 2 domains", len(full.Items))
+	}
+}

--- a/internal/client/domains_test.go
+++ b/internal/client/domains_test.go
@@ -32,6 +32,37 @@ func TestGetDomainList(t *testing.T) {
 	}
 }
 
+// Verifies GetDomainList follows pagination across multiple pages.
+func TestGetDomainList_Paginates(t *testing.T) {
+	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch skip := r.URL.Query().Get("skip"); skip {
+		case "0":
+			_ = json.NewEncoder(w).Encode(DomainList{
+				Items: []DomainInfo{{Name: "a.com"}},
+				Total: 2,
+			})
+		case "100":
+			_ = json.NewEncoder(w).Encode(DomainList{
+				Items: []DomainInfo{{Name: "b.com"}},
+				Total: 2,
+			})
+		default:
+			t.Errorf("unexpected skip=%q", skip)
+		}
+	})
+
+	list, err := c.GetDomainList(t.Context())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(list.Items) != 2 {
+		t.Fatalf("expected 2 domains across pages, got %d", len(list.Items))
+	}
+	if list.Items[0].Name != "a.com" || list.Items[1].Name != "b.com" {
+		t.Errorf("unexpected page contents: %+v", list.Items)
+	}
+}
+
 func TestGetDomainInfo_Success(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(DomainInfo{

--- a/internal/client/domains_test.go
+++ b/internal/client/domains_test.go
@@ -174,7 +174,7 @@ func TestUpdateDomainNameServers(t *testing.T) {
 	})
 
 	err := c.UpdateDomainNameServers(t.Context(), "example.com", UpdateNameserverRequest{
-		Provider: CustomNamerverProvider,
+		Provider: CustomNameserverProvider,
 		Hosts:    []string{"ns1.example.com", "ns2.example.com"},
 	})
 	if err != nil {
@@ -186,7 +186,7 @@ func TestNameserverProvider_Valid(t *testing.T) {
 	if !BasicNameserverProvider.Valid() {
 		t.Error("basic should be valid")
 	}
-	if !CustomNamerverProvider.Valid() {
+	if !CustomNameserverProvider.Valid() {
 		t.Error("custom should be valid")
 	}
 	if NameserverProvider("invalid").Valid() {

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -8,12 +8,15 @@ import (
 	"strings"
 )
 
-// Represents an error response from the Spaceship API.
+// SpaceshipApiError represents a non-2xx error response from the Spaceship API.
+// Status is the HTTP status code; Message is the trimmed response body and may
+// be empty.
 type SpaceshipApiError struct {
 	Status  int
 	Message string
 }
 
+// Error implements the error interface.
 func (e *SpaceshipApiError) Error() string {
 	if e == nil {
 		return "<nil>"
@@ -26,6 +29,9 @@ func (e *SpaceshipApiError) Error() string {
 	return fmt.Sprintf("spaceship api error (status %d)", e.Status)
 }
 
+// errorFromResponse builds a *SpaceshipApiError from a non-2xx response. The
+// body is read up to 64 KiB (LimitReader guards against an unexpectedly large
+// body) and used, trimmed, as the error Message.
 func (c *Client) errorFromResponse(resp *http.Response) error {
 	data, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	if err != nil {
@@ -40,7 +46,8 @@ func (c *Client) errorFromResponse(resp *http.Response) error {
 	}
 }
 
-// returns true if the err represents 404 response
+// IsNotFoundError reports whether err is a *SpaceshipApiError with HTTP 404.
+// Callers use it to treat "already gone" as success on delete paths.
 func IsNotFoundError(err error) bool {
 	var apiErr *SpaceshipApiError
 	if !errors.As(err, &apiErr) {

--- a/internal/client/request.go
+++ b/internal/client/request.go
@@ -9,6 +9,13 @@ import (
 	"net/http"
 )
 
+// doJSON performs a JSON HTTP request against the Spaceship API and decodes the
+// response. It marshals payload as the request body (skipped when nil), applies
+// the API auth headers, and sets Content-Type: application/json only when a body
+// is present. Any response status >= 300 is converted to a *SpaceshipApiError
+// via errorFromResponse. On success the body is decoded into out when out is
+// non-nil. The HTTP status code is always returned, even alongside an error, so
+// callers can branch on it — e.g. the 429 rate-limit fallback in GetDomainInfo.
 func (c *Client) doJSON(ctx context.Context, method, endpoint string, payload any, out any) (int, error) {
 	status := 0
 	var body io.Reader


### PR DESCRIPTION
## Description

Prepares the Spaceship API client for extraction into a standalone SDK (`go-spaceship-sdk`) by polishing it in place first. Three focused, independently-building commits:

- **`fix(client): paginate domain list`** — `GetDomainList` previously fetched only the first 100 domains (`take=100, skip=0`, no loop), silently truncating larger accounts. `GetDomainInfo`'s 429 rate-limit fallback relies on this list and inherited the same gap. It now follows pagination until all pages are retrieved, mirroring the existing `GetDNSRecords` loop. An unexported `listDomains(ctx, pageSize)` seam lets tests force multi-page behavior without owning 100 domains.
- **`refactor(client): correct CustomNamerverProvider typo`** — renames the exported const to `CustomNameserverProvider` while the package is still `internal/`, so the misspelling never becomes a public API contract once the SDK is extracted.
- **`docs(client): document transport and domain methods`** — adds godoc to the request/error/domain methods and types, fixes comments to begin with the identifier name (revive convention), and promotes the 429 fallback from an informal inline comment to a proper doc note. No behavior change.

### Verification of the pagination fix

- Unit test `TestGetDomainList_Paginates` proves the multi-page loop against a mock server.
- The `take`/`skip` params, `{items, total}` response shape, `orderBy=name`, and the **100-item page cap** were verified against the official API docs (docs.spaceship.dev).
- A credential-gated live test (`TestAccGetDomainListPagination`) confirms the contract against the **real API**: it compares `take=1` vs `take=100` retrieval and asserts the `total == len(items)` termination invariant.

> **Note on coverage:** the test account currently holds a single domain, so the multi-page *iteration* branch is not exercised live yet. The test detects this and logs it explicitly rather than passing silently, and auto-upgrades to full multi-page proof once it runs against an account with ≥ 2 domains.

## Related Issues

N/A

## Checklist

- [x] Unit tests added or updated
- [x] `make test` passes
- [x] `golangci-lint run ./...` passes
- [x] `go build .` passes
- [x] `make docs` run if schema changed (and changes committed) — no schema change (client-only), N/A

## Acceptance Test Output

```console
=== RUN   TestAccGetDomainListPagination
    domains_acc_test.go:53: contract confirmed (take/skip/total/orderBy) but only 1 domain in account; multi-page iteration NOT exercised — needs >= 2 domains
--- PASS: TestAccGetDomainListPagination (0.55s)
PASS
ok      terraform-provider-spaceship/internal/client    1.389s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
