### PR TITLE
fix(records): reject apex ALIAS records at plan time

### DIFF
--- a/internal/docs/dns-records.md
+++ b/internal/docs/dns-records.md
@@ -29,6 +29,8 @@ The provider's `recordValueSignature()` function follows the same rules. All fie
 ### Record type notes
 
 - **ALIAS**: Resolves a canonical (true) domain name. Implements CNAME-like behavior for the zone apex where CNAME is not allowed. The `aliasName` field is a hostname (1-253 chars, `hostNameValue` pattern).
+  - **Apex ALIAS (`name = "@"`) is rejected at plan time.** The published `name` regex permits `@`, but the Spaceship API silently stores an apex ALIAS as a **root CNAME** (verified via the UI — see the API's own "CNAME records applied at the domain root..." note). Since records are matched by type + name + data, the read-back CNAME never matches the declared ALIAS, so the provider would recreate it on every apply (non-convergence). The `aliasRecordValidator` rejects `name = "@"` and directs the user to declare it as `type = "CNAME", name = "@", cname = "<target>"` instead — which the API keeps as-is and Terraform can reconcile. This is a provider-side reconciliation guard, not an SDK validation rule: the SDK deliberately does not reject it because the API accepts it.
+  - The **`alias_name` target** is separate: the API returns a 422 for `alias_name = "@"` or `"*"`, so the SDK's `ValidateAliasName` rejects those (a verified live-API divergence from the shared hostname regex, which permits them).
 
 ### Data fields per record type
 

--- a/internal/provider/dns_record_validator_acc_test.go
+++ b/internal/provider/dns_record_validator_acc_test.go
@@ -76,6 +76,34 @@ resource "spaceship_dns_record" "test" {
 	})
 }
 
+// Apex ALIAS (name "@") is rejected on the singular resource. Spaceship stores
+// it as a root CNAME, which Terraform cannot reconcile as an ALIAS.
+func TestAccDNSRecord_aliasApexNameFailsPlan(t *testing.T) {
+	testAccPreCheck(t)
+	domain := testAccDomainValue()
+
+	config := fmt.Sprintf(`
+provider "spaceship" {}
+
+resource "spaceship_dns_record" "test" {
+  domain     = %q
+  type       = "ALIAS"
+  name       = "@"
+  alias_name = "target.example.com"
+}
+`, domain)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("Invalid Apex ALIAS Record"),
+			},
+		},
+	})
+}
+
 func TestAccDNSRecord_caaMissingTagAtPlanTime(t *testing.T) {
 	testAccPreCheck(t)
 	domain := testAccDomainValue()

--- a/internal/provider/record_alias_validator_acc_test.go
+++ b/internal/provider/record_alias_validator_acc_test.go
@@ -69,8 +69,9 @@ func TestAccDNSRecords_aliasRecord(t *testing.T) {
 	})
 }
 
-// Verifies that "@" as alias_name is rejected at plan time (the API requires
-// a real domain name, not the zone-relative apex shorthand).
+// Verifies that "@" as the alias_name *target* is rejected at plan time (the
+// target must be a real domain name, not the apex shorthand). This is distinct
+// from an apex ALIAS record — see TestAccDNSRecords_aliasRecordApexNameFailsPlan.
 func TestAccDNSRecords_aliasRecordApexTargetFailsPlan(t *testing.T) {
 	testAccPreCheck(t)
 
@@ -93,6 +94,74 @@ func TestAccDNSRecords_aliasRecordApexTargetFailsPlan(t *testing.T) {
 			{
 				Config:      testAccDNSRecordsConfig(domain, records),
 				ExpectError: regexp.MustCompile("Invalid Alias Name Value"),
+			},
+		},
+	})
+}
+
+// Verifies that an apex ALIAS (name "@") is rejected at plan time. Spaceship
+// silently stores apex aliases as a root CNAME, which Terraform cannot
+// reconcile as an ALIAS, so the provider rejects it and points at the CNAME form.
+func TestAccDNSRecords_aliasRecordApexNameFailsPlan(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+
+	records := []testAccDNSRecord{
+		{
+			Type: "ALIAS",
+			Name: "@",
+			TTL:  intPtr(3600),
+			StringAttrs: map[string]string{
+				"alias_name": "target.example.com",
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDNSRecordsConfig(domain, records),
+				ExpectError: regexp.MustCompile("Invalid Apex ALIAS Record"),
+			},
+		},
+	})
+}
+
+// Verifies that an apex ALIAS (name "@") is rejected even when it sits among
+// other valid records — the per-element validator must fire on the offending
+// record, not just when the ALIAS is the sole record in the list.
+func TestAccDNSRecords_aliasRecordApexNameAmongMultipleFailsPlan(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+
+	records := []testAccDNSRecord{
+		{
+			Type: "A",
+			Name: aliasHost("multi-a"),
+			TTL:  intPtr(3600),
+			StringAttrs: map[string]string{
+				"address": "192.0.2.1",
+			},
+		},
+		{
+			Type: "ALIAS",
+			Name: "@",
+			TTL:  intPtr(3600),
+			StringAttrs: map[string]string{
+				"alias_name": "target.example.com",
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDNSRecordsConfig(domain, records),
+				ExpectError: regexp.MustCompile("Invalid Apex ALIAS Record"),
 			},
 		},
 	})

--- a/internal/provider/records/record_alias_validator.go
+++ b/internal/provider/records/record_alias_validator.go
@@ -43,6 +43,20 @@ func (v *aliasRecordValidator) ValidateObject(ctx context.Context, req validator
 		return
 	}
 
+	// Spaceship stores an apex ALIAS (name "@") as a root CNAME, not an ALIAS.
+	// Terraform matches records by type+name+data, so the record read back never
+	// matches the declared ALIAS and the provider recreates it on every apply.
+	// Reject early and point the user at the CNAME form the API actually keeps.
+	if nameAttr, ok := attrs["name"].(types.String); ok && !nameAttr.IsNull() && !nameAttr.IsUnknown() && nameAttr.ValueString() == "@" {
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtName("name"),
+			"Invalid Apex ALIAS Record",
+			`Spaceship stores an apex ALIAS (name "@") as a root CNAME, so Terraform cannot manage it as an ALIAS record (it would be recreated on every apply). `+
+				`Declare it as a CNAME instead: type = "CNAME", name = "@", cname = "<target>".`,
+		)
+		return
+	}
+
 	aliasNameAttr, ok := attrs["alias_name"].(types.String)
 	if !ok {
 		resp.Diagnostics.AddAttributeError(

--- a/internal/provider/records/record_alias_validator_test.go
+++ b/internal/provider/records/record_alias_validator_test.go
@@ -1,0 +1,68 @@
+package records
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Spaceship silently stores an apex ALIAS (name "@") as a root CNAME, so
+// Terraform can never reconcile it as an ALIAS and would recreate it on every
+// apply. Reject it at plan time and point the user at the CNAME form instead.
+func TestALIASValidator_RejectsApexName(t *testing.T) {
+	obj := buildRecordObject(t, map[string]attr.Value{
+		"type":       types.StringValue("ALIAS"),
+		"name":       types.StringValue("@"),
+		"alias_name": types.StringValue("target.example.com"),
+	})
+
+	resp := &validator.ObjectResponse{}
+	ALIASValidator().ValidateObject(context.Background(),
+		validator.ObjectRequest{Path: path.Empty(), ConfigValue: obj}, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected apex ALIAS (name \"@\") to be rejected, got no error")
+	}
+	if !strings.Contains(resp.Diagnostics.Errors()[0].Summary(), "Invalid Apex ALIAS") {
+		t.Errorf("unexpected diagnostic: %s", resp.Diagnostics.Errors()[0])
+	}
+}
+
+// A non-apex ALIAS with a valid target round-trips fine and must pass.
+func TestALIASValidator_AllowsNonApexName(t *testing.T) {
+	obj := buildRecordObject(t, map[string]attr.Value{
+		"type":       types.StringValue("ALIAS"),
+		"name":       types.StringValue("www"),
+		"alias_name": types.StringValue("target.example.com"),
+	})
+
+	resp := &validator.ObjectResponse{}
+	ALIASValidator().ValidateObject(context.Background(),
+		validator.ObjectRequest{Path: path.Empty(), ConfigValue: obj}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected non-apex ALIAS to pass, got: %s", resp.Diagnostics)
+	}
+}
+
+// The apex check is scoped to ALIAS only — other types legitimately use "@".
+func TestALIASValidator_IgnoresApexNameForOtherTypes(t *testing.T) {
+	obj := buildRecordObject(t, map[string]attr.Value{
+		"type":    types.StringValue("A"),
+		"name":    types.StringValue("@"),
+		"address": types.StringValue("192.0.2.1"),
+	})
+
+	resp := &validator.ObjectResponse{}
+	ALIASValidator().ValidateObject(context.Background(),
+		validator.ObjectRequest{Path: path.Empty(), ConfigValue: obj}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected non-ALIAS type to be a no-op, got: %s", resp.Diagnostics)
+	}
+}


### PR DESCRIPTION
## What

Reject apex ALIAS records (`type = "ALIAS"`, `name = "@"`) at plan time.

## Why

Spaceship silently stores an apex ALIAS as a **root CNAME**, not an ALIAS. Because the provider matches records by type + name + data, the read-back CNAME never matches the declared ALIAS, so the record is recreated on **every apply** (non-convergence).

The validator now rejects `name = "@"` for ALIAS with a clear diagnostic pointing users at the form the API actually keeps:

```hcl
type = "CNAME", name = "@", cname = "<target>"
```

This is distinct from the existing `alias_name = "@"` rejection (the *target* field), which is enforced by the SDK's `ValidateAliasName`.

## Tests

- Unit: apex rejected, non-apex allowed, non-ALIAS types ignored.
- Acc (single resource): `TestAccDNSRecord_aliasApexNameFailsPlan`.
- Acc (multiple-record resource): apex alone, and apex mixed among valid records.

`make test`, `make lint`, and `go build .` all pass; acceptance tests confirmed passing locally.