### PR TITLE
ci: add Dependabot with releasing commit-type prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    # Go module bumps change the SHIPPED provider binary, so they must land as
+    # a releasing Conventional Commit type. release-please maps `fix:` -> patch,
+    # which opens/refreshes the Release PR and actually ships the dependency.
+    # Dependabot's default `chore(deps):` is NON-releasing, so without this
+    # bumps would sit unreleased until an unrelated fix:/feat: swept them in.
+    # `include: scope` yields `fix(deps): ...`. See CLAUDE.md > Release process.
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    # Action bumps are CI-only and never touch the shipped binary, so they use
+    # a NON-releasing type (`ci`) and must not cut a release.
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,3 +70,10 @@ Acc tests (`record_<type>_validator_acc_test.go`) own API edge cases: unusual va
 ## Release process
 
 Releases are semi-manual and maintainer-gated: merges to `master` accumulate into a release-please "Release PR"; a maintainer merges that PR to cut a tag, and GoReleaser publishes the binary. See [RELEASE.md](RELEASE.md) for the full flow, including the manual Terraform Registry resync that is occasionally required.
+
+**Only releasing commit types cut a release**: `fix:` → patch, `feat:` → minor, `feat!:`/`BREAKING CHANGE:` → major; `chore:`/`ci:`/`refactor:`/`test:`/`docs:` are non-releasing. The trap is **published artifacts** — anything shipped to users must ride a release:
+
+- **Runtime deps** (`go.mod`) ship in the binary → commit as `fix(deps):`, never `chore(deps):` (which never releases, so the bump reaches nobody).
+- **Registry docs** (the `docs/` tree) are ingested by the Terraform Registry only at a release tag → correct them with `fix(docs):`. Repo-internal markdown (README, `RELEASE.md`, `CLAUDE.md`) stays `docs:`.
+
+For Dependabot this is enforced via `commit-message.prefix` in `.github/dependabot.yml` (gomod → `fix`, github-actions → `ci`).


### PR DESCRIPTION
## Why

This repo uses release-please but had **no** `.github/dependabot.yml`, and release-please only bumps on `fix:`/`feat:`/breaking. Sibling repo `terraform-provider-namecheap` hit a related problem: dependency bumps landed as non-releasing `chore(deps):` and never shipped. This adds Dependabot here with the correct releasing behavior baked in from the start.

## What

New `.github/dependabot.yml` (weekly, gomod + github-actions):

| Ecosystem | Prefix | Result | Release effect |
|-----------|--------|--------|----------------|
| `gomod` (runtime deps) | `fix` + scope | `fix(deps): …` | **patch release** ✓ |
| `github-actions` (CI only) | `ci` + scope | `ci(deps): …` | non-releasing (correct) |

Plus a CLAUDE.md convention: changes to **published artifacts** — the binary (`go.mod`) or the registry-published `docs/` tree — need a releasing type (`fix(deps):`, `fix(docs):`); repo-internal markdown stays `docs:`. The Terraform Registry only ingests provider docs at a release tag, so doc corrections must ride a release.

Part of a cross-repo consistency pass (namecheap #283, go-spaceship-sdk).