### PR TITLE
ci(deps): group dependabot updates per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,17 @@ updates:
     commit-message:
       prefix: "fix"
       include: "scope"
+    # One PR for all Go bumps. Acceptance tests then run against the COMBINED
+    # dependency set — exactly what master will contain after merge — and a
+    # burst of per-dep PRs can't cancel each other in the acceptance-tests
+    # concurrency group (GitHub queues at most ONE pending job per group;
+    # newer arrivals cancel the waiting one). If one bump in the group breaks
+    # tests, add it to exclude-patterns so the rest can merge, then handle it
+    # separately.
+    groups:
+      go-deps:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -25,3 +36,8 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    # One PR for all action bumps, same rationale as the gomod group.
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Why

When Dependabot was enabled it opened 7 PRs at once, and their CI runs raced the `acceptance-tests` concurrency group. GitHub holds one running job plus a pending queue of exactly **one** per group — every newer arrival cancels whoever is waiting — so 5 of the 7 acceptance jobs were cancelled ("Canceled by higher priority waiting request") and those PRs were never actually verified.

## What

Group updates per ecosystem in `dependabot.yml`:

- **gomod** → one weekly `fix(deps)` PR with all Go bumps. Acceptance tests then run against the combined dependency set — exactly what `master` contains after merge — instead of each bump tested in isolation against stale versions of the others.
- **github-actions** → one weekly `ci(deps)` PR. Since `pull_request` runs use the workflow files from the PR branch, the bumped actions are exercised by the PR's own CI (including the acceptance job's setup steps) before merge.

A Monday burst is now at most 2 simultaneous runs, which the depth-1 concurrency queue handles without cancelling anything. If one bump inside a group breaks tests, add it to `exclude-patterns` so the rest can merge, then handle it separately.