### PR TITLE
fix(domain): apply configured auto_renew and nameservers on create

### DIFF
--- a/internal/provider/domain_resource.go
+++ b/internal/provider/domain_resource.go
@@ -295,11 +295,56 @@ func (d *domainResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	domainInfo, err := d.client.GetDomainInfo(ctx, plan.Domain.ValueString())
+	domainName := plan.Domain.ValueString()
+
+	domainInfo, err := d.client.GetDomainInfo(ctx, domainName)
 
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read domain info", err.Error())
 		return
+	}
+
+	// Adoption must converge the domain to the configured settings. Otherwise
+	// a config/infra mismatch on the first apply stores the actual values
+	// while the plan promised the configured ones, and Terraform fails with
+	// "Provider produced inconsistent result after apply".
+	if !plan.AutoRenew.IsNull() && !plan.AutoRenew.IsUnknown() && plan.AutoRenew.ValueBool() != domainInfo.AutoRenew {
+		_, err := d.client.UpdateAutoRenew(ctx, domainName, plan.AutoRenew.ValueBool())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error updating domain auto_renew",
+				fmt.Sprintf("Could not update auto_renew for domain %s: %s", domainName, err),
+			)
+			return
+		}
+	}
+
+	// Nested attributes can still be unknown at create (there is no prior
+	// state for UseStateForUnknown to resolve them); in that case fall back
+	// to adopting the API values.
+	nsPlanKnown := false
+	if !plan.Nameservers.IsNull() && !plan.Nameservers.IsUnknown() {
+		var planNS nameservers
+		resp.Diagnostics.Append(plan.Nameservers.As(ctx, &planNS, basetypes.ObjectAsOptions{})...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		nsPlanKnown = !planNS.Provider.IsUnknown() && !planNS.Hosts.IsUnknown()
+	}
+
+	if nsPlanKnown {
+		infraNS, nsDiags := nameserversToTerraformObject(ctx, domainInfo.Nameservers)
+		resp.Diagnostics.Append(nsDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if !plan.Nameservers.Equal(infraNS) {
+			resp.Diagnostics.Append(d.pushNameservers(ctx, domainName, plan.Nameservers)...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+		}
 	}
 
 	var state domainResourceModel
@@ -310,6 +355,16 @@ func (d *domainResource) Create(ctx context.Context, req resource.CreateRequest,
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// The autorenew and nameserver update APIs confirm changes synchronously;
+	// trust the plan values over the pre-update read (same rule as Update).
+	if !plan.AutoRenew.IsNull() && !plan.AutoRenew.IsUnknown() {
+		state.AutoRenew = plan.AutoRenew
+	}
+	if nsPlanKnown {
+		state.Nameservers = plan.Nameservers
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 
 }
@@ -354,33 +409,8 @@ func (d *domainResource) Update(ctx context.Context, req resource.UpdateRequest,
 	if !plan.Nameservers.IsNull() && !plan.Nameservers.IsUnknown() {
 		// Use Terraform's built-in Equal() - it handles sets correctly (order-independent)
 		if !plan.Nameservers.Equal(state.Nameservers) {
-			var planNS nameservers
-			resp.Diagnostics.Append(plan.Nameservers.As(ctx, &planNS, basetypes.ObjectAsOptions{})...)
+			resp.Diagnostics.Append(d.pushNameservers(ctx, domainName, plan.Nameservers)...)
 			if resp.Diagnostics.HasError() {
-				return
-			}
-
-			provider := client.NameserverProvider(planNS.Provider.ValueString())
-
-			var hosts []string
-			if !planNS.Hosts.IsNull() && !planNS.Hosts.IsUnknown() {
-				resp.Diagnostics.Append(planNS.Hosts.ElementsAs(ctx, &hosts, false)...)
-				if resp.Diagnostics.HasError() {
-					return
-				}
-			}
-
-			// API ignores hosts for basic provider
-			if provider == client.BasicNameserverProvider {
-				hosts = nil
-			}
-
-			err := d.client.UpdateDomainNameServers(ctx, domainName, client.UpdateNameserverRequest{
-				Provider: provider,
-				Hosts:    hosts,
-			})
-			if err != nil {
-				resp.Diagnostics.AddError("Failed to update domain nameservers", err.Error())
 				return
 			}
 		}
@@ -470,6 +500,42 @@ func (d *domainResource) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 		return
 	}
 	resp.Plan.SetAttribute(ctx, path.Root("nameservers").AtName("hosts"), hostsSet)
+}
+
+// pushNameservers applies the planned nameservers object to the API.
+func (d *domainResource) pushNameservers(ctx context.Context, domainName string, planNameservers types.Object) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	var planNS nameservers
+	diags.Append(planNameservers.As(ctx, &planNS, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return diags
+	}
+
+	provider := client.NameserverProvider(planNS.Provider.ValueString())
+
+	var hosts []string
+	if !planNS.Hosts.IsNull() && !planNS.Hosts.IsUnknown() {
+		diags.Append(planNS.Hosts.ElementsAs(ctx, &hosts, false)...)
+		if diags.HasError() {
+			return diags
+		}
+	}
+
+	// API ignores hosts for basic provider
+	if provider == client.BasicNameserverProvider {
+		hosts = nil
+	}
+
+	err := d.client.UpdateDomainNameServers(ctx, domainName, client.UpdateNameserverRequest{
+		Provider: provider,
+		Hosts:    hosts,
+	})
+	if err != nil {
+		diags.AddError("Failed to update domain nameservers", err.Error())
+	}
+
+	return diags
 }
 
 func applyDomainInfo(ctx context.Context, state *domainResourceModel, info client.DomainInfo) diag.Diagnostics {

--- a/internal/provider/domain_resource.go
+++ b/internal/provider/domain_resource.go
@@ -287,7 +287,6 @@ func (d *domainResource) Configure(ctx context.Context, req resource.ConfigureRe
 
 func (d *domainResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan domainResourceModel
-	var domainInfo client.DomainInfo
 
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/domain_resource_acc_test.go
+++ b/internal/provider/domain_resource_acc_test.go
@@ -1,12 +1,16 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/namecheap/go-spaceship-sdk/client"
 )
 
 const (
@@ -130,6 +134,69 @@ resource "%s" "%s" {
 		}})
 }
 
+// TestAccDomain_autoRenewalMismatchOnCreate verifies the first apply converges
+// auto_renew when the config value differs from the domain's actual setting.
+func TestAccDomain_autoRenewalMismatchOnCreate(t *testing.T) {
+	configAutoRenewTrue := domainConfigWithAutoRenew(true)
+	configAutoRenewFalse := domainConfigWithAutoRenew(false)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// infra false, config true — Create must push the change
+			{
+				PreConfig: func() { testAccSetAutoRenew(t, false) },
+				Config:    configAutoRenewTrue,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(domainResourceFullName, "auto_renew", "true"),
+				),
+			},
+			// reverse direction on a forced recreate: infra true, config false
+			{
+				PreConfig: func() { testAccSetAutoRenew(t, true) },
+				Taint:     []string{domainResourceFullName},
+				Config:    configAutoRenewFalse,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(domainResourceFullName, "auto_renew", "false"),
+				),
+			},
+			// converged: re-plan is empty
+			{
+				Config: configAutoRenewFalse,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+		},
+	})
+}
+
+// testAccSetAutoRenew sets the test domain's auto_renew out-of-band via the SDK.
+func testAccSetAutoRenew(t *testing.T, value bool) {
+	t.Helper()
+
+	testClient, err := testAccClient()
+	if err != nil {
+		t.Fatalf("failed to create test client: %v", err)
+	}
+	if _, err := testClient.UpdateAutoRenew(context.Background(), testAccDomainValue(), value); err != nil {
+		t.Fatalf("failed to set auto_renew=%v: %v", value, err)
+	}
+}
+
+func domainConfigWithAutoRenew(value bool) string {
+	return fmt.Sprintf(`
+provider "%s" {}
+
+resource "%s" "%s" {
+	domain = "%s"
+
+	auto_renew = %t
+}
+`, providerName, domainResourceRef, domainResourceName, testAccDomainValue(), value)
+}
+
 func TestAccDomain_nameservers(t *testing.T) {
 	nsProviderBasicConfig := fmt.Sprintf(`
 provider "%s" {}
@@ -204,6 +271,122 @@ resource "%s" "%s" {
 			},
 		},
 	})
+}
+
+// TestAccDomain_nameserversMismatchOnCreate verifies the first apply converges
+// nameservers when the config differs from the domain's actual setting.
+func TestAccDomain_nameserversMismatchOnCreate(t *testing.T) {
+	customHosts := []string{
+		"ns-669.awsdns-19.net",
+		"ns-1578.awsdns-05.co.uk",
+	}
+
+	configCustom := fmt.Sprintf(`
+provider "%s" {}
+
+resource "%s" "%s" {
+	domain = "%s"
+
+	nameservers = {
+		provider = "custom"
+		hosts = [
+			"ns-669.awsdns-19.net",
+			"ns-1578.awsdns-05.co.uk",
+		]
+	}
+}
+`, providerName, domainResourceRef, domainResourceName, testAccDomainValue())
+
+	configBasic := fmt.Sprintf(`
+provider "%s" {}
+
+resource "%s" "%s" {
+	domain = "%s"
+
+	nameservers = {
+		provider = "basic"
+	}
+}
+`, providerName, domainResourceRef, domainResourceName, testAccDomainValue())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// infra basic, config custom — Create must push the change
+			{
+				PreConfig: func() { testAccSetNameservers(t, "basic", nil) },
+				Config:    configCustom,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(domainResourceFullName, "nameservers.provider", "custom"),
+					resource.TestCheckTypeSetElemAttr(domainResourceFullName, "nameservers.hosts.*", "ns-669.awsdns-19.net"),
+					resource.TestCheckTypeSetElemAttr(domainResourceFullName, "nameservers.hosts.*", "ns-1578.awsdns-05.co.uk"),
+				),
+			},
+			// reverse direction on a forced recreate: infra custom, config basic
+			{
+				PreConfig: func() { testAccSetNameservers(t, "custom", customHosts) },
+				Taint:     []string{domainResourceFullName},
+				Config:    configBasic,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(domainResourceFullName, "nameservers.provider", "basic"),
+					resource.TestCheckTypeSetElemAttr(domainResourceFullName, "nameservers.hosts.*", "launch1.spaceship.net"),
+				),
+			},
+			// converged: re-plan is empty
+			{
+				Config: configBasic,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
+		},
+	})
+}
+
+// testAccSetNameservers sets the test domain's nameservers out-of-band via the
+// SDK. The API rejects updates matching the current provider, so it skips when
+// the domain is already in the desired state.
+func testAccSetNameservers(t *testing.T, nsProvider string, hosts []string) {
+	t.Helper()
+
+	testClient, err := testAccClient()
+	if err != nil {
+		t.Fatalf("failed to create test client: %v", err)
+	}
+
+	info, err := testClient.GetDomainInfo(context.Background(), testAccDomainValue())
+	if err != nil {
+		t.Fatalf("failed to read domain info: %v", err)
+	}
+	if strings.EqualFold(info.Nameservers.Provider, nsProvider) &&
+		(strings.EqualFold(nsProvider, "basic") || sameHostSet(info.Nameservers.Hosts, hosts)) {
+		return
+	}
+
+	err = testClient.UpdateDomainNameServers(context.Background(), testAccDomainValue(), client.UpdateNameserverRequest{
+		Provider: client.NameserverProvider(nsProvider),
+		Hosts:    hosts,
+	})
+	if err != nil {
+		t.Fatalf("failed to set nameservers provider=%s: %v", nsProvider, err)
+	}
+}
+
+func sameHostSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	set := make(map[string]struct{}, len(a))
+	for _, h := range a {
+		set[strings.ToLower(h)] = struct{}{}
+	}
+	for _, h := range b {
+		if _, ok := set[strings.ToLower(h)]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func TestAccDomain_nameserversValidationErrors(t *testing.T) {

--- a/internal/provider/domain_resource_acc_test.go
+++ b/internal/provider/domain_resource_acc_test.go
@@ -152,6 +152,13 @@ func TestAccDomain_autoRenewalMismatchOnCreate(t *testing.T) {
 					resource.TestCheckResourceAttr(domainResourceFullName, "auto_renew", "true"),
 				),
 			},
+			// converged for real: refresh-backed empty plan
+			{
+				Config: configAutoRenewTrue,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+			},
 			// reverse direction on a forced recreate: infra true, config false
 			{
 				PreConfig: func() { testAccSetAutoRenew(t, true) },
@@ -322,6 +329,13 @@ resource "%s" "%s" {
 					resource.TestCheckTypeSetElemAttr(domainResourceFullName, "nameservers.hosts.*", "ns-669.awsdns-19.net"),
 					resource.TestCheckTypeSetElemAttr(domainResourceFullName, "nameservers.hosts.*", "ns-1578.awsdns-05.co.uk"),
 				),
+			},
+			// converged for real: refresh-backed empty plan
+			{
+				Config: configCustom,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
 			},
 			// reverse direction on a forced recreate: infra custom, config basic
 			{


### PR DESCRIPTION
## Problem

The domain resource adopts existing domains on create, but `Create` stored whatever `GetDomainInfo` returned while ignoring the planned `auto_renew` and `nameservers`. Any config/infra mismatch on the first apply made Terraform fail with:

```
Error: Provider produced inconsistent result after apply
.auto_renew: was cty.True, but now cty.False.
```

Since the error fires on the first apply, `Update` (which handles both settings correctly) was never reachable — `auto_renew` could effectively never be changed.

## Fix

`Create` now mirrors `Update`'s converge-then-trust pattern:

- If the configured `auto_renew` differs from the domain's actual value, push it via `UpdateAutoRenew` (no write when they already match).
- Same for `nameservers` via a new shared `pushNameservers` helper, now used by both `Create` and `Update`. The converge is skipped when nested attributes are still unknown at create (no prior state for `UseStateForUnknown` to resolve), falling back to plain adoption.
- State trusts the plan values over the pre-update read, same stale-read rule as `Update`.

## Tests

New acceptance tests force the real domain to the opposite setting via the SDK in `PreConfig` before the first apply, cover the reverse direction through a tainted recreate, and assert an empty re-plan:

- `TestAccDomain_autoRenewalMismatchOnCreate`
- `TestAccDomain_nameserversMismatchOnCreate`

Both failed with the exact reported error before the fix and pass after. Existing `TestAccDomain_autoRenewal`, `TestAccDomain_nameservers`, and `TestAccDomain_nameserversValidationErrors` still pass against the real API.