### PR TITLE
fix(records): reject duplicate records in one list at plan time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,10 @@ After making changes, follow this order:
 - Internal design notes live in `internal/docs/`.
 - Provider reads `SPACESHIP_API_KEY` / `SPACESHIP_API_SECRET` env vars or inline HCL attributes.
 
-## Git privacy
+## Open-source hygiene
 
-Before creating git commits, check that `git config user.email` is set. If it is not configured, suggest the contributor set one. Do not override an already-configured email.
+- Before creating git commits, check that `git config user.email` is set. If it is not configured, suggest the contributor set one. Do not override an already-configured email.
+- **No internal tracker IDs** (e.g. Jira `DEVOPS-*`) in code, comments, tests, or docs — they mean nothing to outside readers. Describe the behavior or failure itself instead; ticket references belong in the internal tracker, not the repo.
 
 ## Testing strategy
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module terraform-provider-spaceship
 
 go 1.25.9
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.19.0

--- a/internal/docs/dns-records.md
+++ b/internal/docs/dns-records.md
@@ -26,6 +26,12 @@ The `PUT /dns/records/{domain}` endpoint matches existing records by **type + na
 
 The provider's `recordValueSignature()` function follows the same rules. All fields are lowercased in the signature except TXT `value`, ensuring the provider's diff logic agrees with the API about what constitutes "the same record".
 
+### Duplicate entries are rejected at plan time
+
+Because the API dedups a submitted set by that identity, two entries in one `spaceship_dns_records.records` list that share type + name + data (however they differ in case or TTL) can never converge: the plan holds N elements, the post-apply read returns fewer, and Terraform fails with "Provider produced inconsistent result after apply". `duplicateRecordsValidator` (a `validator.List` on the `records` attribute) rejects such configs at plan time using `client.RecordKey` as the identity. Elements containing unknown values are skipped — their identity is not computable during plan.
+
+This guard is list-scoped only. Two *separate* resources (e.g. two `spaceship_dns_record` instances, or a record repeated across two `spaceship_dns_records` lists for different modules) declaring the same record cannot be detected at plan time; the second writer silently adopts the first's record.
+
 ### Record type notes
 
 - **ALIAS**: Resolves a canonical (true) domain name. Implements CNAME-like behavior for the zone apex where CNAME is not allowed. The `aliasName` field is a hostname (1-253 chars, `hostNameValue` pattern).

--- a/internal/provider/dns_records_duplicate_validator.go
+++ b/internal/provider/dns_records_duplicate_validator.go
@@ -1,0 +1,88 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+	"github.com/namecheap/go-spaceship-sdk/client"
+)
+
+// duplicateRecordsValidator rejects records lists containing entries the
+// Spaceship API would treat as the same record. The API silently dedups such
+// entries on write, so the post-apply read returns fewer records than planned
+// and Terraform fails with "inconsistent result after apply". Identity follows
+// client.RecordKey: type + name + data case-insensitive, except TXT values.
+type duplicateRecordsValidator struct{}
+
+var _ validator.List = duplicateRecordsValidator{}
+
+func (v duplicateRecordsValidator) Description(_ context.Context) string {
+	return "records must be unique by type + name + data (case-insensitive, except TXT values)"
+}
+
+func (v duplicateRecordsValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v duplicateRecordsValidator) ValidateList(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	firstIndexByKey := make(map[string]int)
+
+	for idx, element := range req.ConfigValue.Elements() {
+		object, ok := element.(types.Object)
+		if !ok || object.IsNull() || object.IsUnknown() {
+			continue
+		}
+		// An unknown field ("known after apply") makes the record's API identity
+		// uncomputable at plan time; comparing partial keys would flag false
+		// duplicates, so skip the element instead.
+		if recordHasUnknownAttribute(object) {
+			continue
+		}
+
+		var model dnsRecordModel
+		if diags := object.As(ctx, &model, basetypes.ObjectAsOptions{}); diags.HasError() {
+			continue
+		}
+
+		// Conversion diagnostics (missing type/name/data fields) are owned by the
+		// schema and per-type object validators; here they only mean the record
+		// has no computable identity yet, so drop them and skip the element.
+		record, diags := modelToDNSRecord(model, req.Path.AtListIndex(idx))
+		if diags.HasError() {
+			continue
+		}
+
+		key := client.RecordKey(record)
+		firstIdx, seen := firstIndexByKey[key]
+		if !seen {
+			firstIndexByKey[key] = idx
+			continue
+		}
+
+		resp.Diagnostics.AddAttributeError(
+			req.Path.AtListIndex(idx),
+			"Duplicate DNS Record",
+			fmt.Sprintf(
+				"This entry duplicates records[%d]. The Spaceship API matches records by type + name + data case-insensitively (TXT values are case-sensitive) and stores only one copy, so the apply can never converge. Remove one of the entries.",
+				firstIdx,
+			),
+		)
+	}
+}
+
+func recordHasUnknownAttribute(object types.Object) bool {
+	for _, value := range object.Attributes() {
+		if value.IsUnknown() {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/provider/dns_records_duplicate_validator_test.go
+++ b/internal/provider/dns_records_duplicate_validator_test.go
@@ -1,0 +1,156 @@
+package provider
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Duplicate detection must mirror the API's record identity (client.RecordKey):
+// type + name + data case-insensitive, except TXT values which are case-sensitive.
+// TTL is not part of the identity.
+func TestDuplicateRecordsValidator(t *testing.T) {
+	aRecord := func(name, address string) dnsRecordModel {
+		return dnsRecordModel{
+			Type:    types.StringValue("A"),
+			Name:    types.StringValue(name),
+			Address: types.StringValue(address),
+		}
+	}
+	txtRecord := func(name, value string) dnsRecordModel {
+		return dnsRecordModel{
+			Type:  types.StringValue("TXT"),
+			Name:  types.StringValue(name),
+			Value: types.StringValue(value),
+		}
+	}
+
+	cases := []struct {
+		name       string
+		records    []dnsRecordModel
+		wantErrors int
+	}{
+		{
+			name:       "exact duplicates",
+			records:    []dnsRecordModel{aRecord("www", "192.0.2.1"), aRecord("www", "192.0.2.1")},
+			wantErrors: 1,
+		},
+		{
+			name:       "name case-folded duplicates",
+			records:    []dnsRecordModel{aRecord("WWW", "192.0.2.1"), aRecord("www", "192.0.2.1")},
+			wantErrors: 1,
+		},
+		{
+			name: "data case-folded duplicates",
+			records: []dnsRecordModel{
+				{Type: types.StringValue("CNAME"), Name: types.StringValue("app"), CName: types.StringValue("Target.Example.COM")},
+				{Type: types.StringValue("CNAME"), Name: types.StringValue("app"), CName: types.StringValue("target.example.com")},
+			},
+			wantErrors: 1,
+		},
+		{
+			name:       "duplicates differing only in TTL",
+			records:    []dnsRecordModel{aRecord("www", "192.0.2.1"), withTTL(aRecord("www", "192.0.2.1"), 300)},
+			wantErrors: 1,
+		},
+		{
+			name:       "TXT values differing only in case are distinct",
+			records:    []dnsRecordModel{txtRecord("@", "Hello"), txtRecord("@", "hello")},
+			wantErrors: 0,
+		},
+		{
+			name:       "TXT identical values are duplicates",
+			records:    []dnsRecordModel{txtRecord("@", "hello"), txtRecord("@", "hello")},
+			wantErrors: 1,
+		},
+		{
+			name:       "same host different data is distinct",
+			records:    []dnsRecordModel{aRecord("www", "192.0.2.1"), aRecord("www", "192.0.2.2")},
+			wantErrors: 0,
+		},
+		{
+			name:       "triplicate reports each later occurrence",
+			records:    []dnsRecordModel{aRecord("www", "192.0.2.1"), aRecord("www", "192.0.2.1"), aRecord("www", "192.0.2.1")},
+			wantErrors: 2,
+		},
+		{
+			name: "unknown data fields are skipped, no false positive",
+			records: []dnsRecordModel{
+				{Type: types.StringValue("A"), Name: types.StringValue("www"), Address: types.StringUnknown()},
+				{Type: types.StringValue("A"), Name: types.StringValue("www"), Address: types.StringUnknown()},
+			},
+			wantErrors: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &validator.ListResponse{}
+			duplicateRecordsValidator{}.ValidateList(context.Background(), validator.ListRequest{
+				Path:        path.Root("records"),
+				ConfigValue: buildRecordList(t, tc.records...),
+			}, resp)
+
+			if got := resp.Diagnostics.ErrorsCount(); got != tc.wantErrors {
+				t.Fatalf("expected %d errors, got %d: %s", tc.wantErrors, got, resp.Diagnostics)
+			}
+		})
+	}
+}
+
+// The error must land on the later duplicate's list index and point back at the
+// first occurrence so the user knows which line to keep.
+func TestDuplicateRecordsValidator_ErrorPlacement(t *testing.T) {
+	records := []dnsRecordModel{
+		{Type: types.StringValue("A"), Name: types.StringValue("keep"), Address: types.StringValue("192.0.2.10")},
+		{Type: types.StringValue("TXT"), Name: types.StringValue("@"), Value: types.StringValue("v=spf1 -all")},
+		{Type: types.StringValue("TXT"), Name: types.StringValue("@"), Value: types.StringValue("v=spf1 -all")},
+	}
+
+	resp := &validator.ListResponse{}
+	duplicateRecordsValidator{}.ValidateList(context.Background(), validator.ListRequest{
+		Path:        path.Root("records"),
+		ConfigValue: buildRecordList(t, records...),
+	}, resp)
+
+	if got := resp.Diagnostics.ErrorsCount(); got != 1 {
+		t.Fatalf("expected exactly 1 error, got %d: %s", got, resp.Diagnostics)
+	}
+
+	diagnostic := resp.Diagnostics.Errors()[0]
+	wantPath := path.Root("records").AtListIndex(2)
+	if withPath, ok := diagnostic.(interface{ Path() path.Path }); !ok || !withPath.Path().Equal(wantPath) {
+		t.Errorf("expected error at %s, got %v", wantPath, diagnostic)
+	}
+	if !strings.Contains(diagnostic.Detail(), "records[1]") {
+		t.Errorf("expected detail to reference first occurrence records[1], got: %s", diagnostic.Detail())
+	}
+}
+
+// Null and unknown lists are not validatable and must not panic or error.
+func TestDuplicateRecordsValidator_NullUnknownList(t *testing.T) {
+	for name, value := range map[string]types.List{
+		"null":    types.ListNull(dnsRecordObjectType),
+		"unknown": types.ListUnknown(dnsRecordObjectType),
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp := &validator.ListResponse{}
+			duplicateRecordsValidator{}.ValidateList(context.Background(), validator.ListRequest{
+				Path:        path.Root("records"),
+				ConfigValue: value,
+			}, resp)
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("expected no errors, got: %s", resp.Diagnostics)
+			}
+		})
+	}
+}
+
+func withTTL(model dnsRecordModel, ttl int64) dnsRecordModel {
+	model.TTL = types.Int64Value(ttl)
+	return model
+}

--- a/internal/provider/dns_records_resource.go
+++ b/internal/provider/dns_records_resource.go
@@ -86,6 +86,9 @@ func (r *dnsRecordsResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.UseStateForUnknown(),
 				},
+				Validators: []validator.List{
+					duplicateRecordsValidator{},
+				},
 				NestedObject: schema.NestedAttributeObject{
 					Validators: recordTypeObjectValidators(),
 					Attributes: recordAttributes(),

--- a/internal/provider/dns_records_resource_acc_test.go
+++ b/internal/provider/dns_records_resource_acc_test.go
@@ -506,6 +506,70 @@ func TestAccDNSRecords_matchingRecordsNoChanges(t *testing.T) {
 	})
 }
 
+// Two identical entries in one records list are rejected at plan time. The
+// API would dedup them on write, so the apply could never converge.
+func TestAccDNSRecords_duplicateRecordsFailPlan(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+
+	record := testAccDNSRecord{
+		Type: "A",
+		Name: "dup-a",
+		TTL:  intPtr(3600),
+		StringAttrs: map[string]string{
+			"address": "192.0.2.1",
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDNSRecordsConfig(domain, []testAccDNSRecord{record, record}),
+				ExpectError: regexp.MustCompile("Duplicate DNS Record"),
+			},
+		},
+	})
+}
+
+// Duplicate detection mirrors the API's case-insensitive matching: entries
+// differing only in name case are the same record and are rejected at plan time.
+func TestAccDNSRecords_duplicateRecordsCaseFoldedFailPlan(t *testing.T) {
+	testAccPreCheck(t)
+
+	domain := testAccDomainValue()
+
+	records := []testAccDNSRecord{
+		{
+			Type: "A",
+			Name: "DUP-CASE",
+			TTL:  intPtr(3600),
+			StringAttrs: map[string]string{
+				"address": "192.0.2.1",
+			},
+		},
+		{
+			Type: "A",
+			Name: "dup-case",
+			TTL:  intPtr(3600),
+			StringAttrs: map[string]string{
+				"address": "192.0.2.1",
+			},
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDNSRecordsConfig(domain, records),
+				ExpectError: regexp.MustCompile("Duplicate DNS Record"),
+			},
+		},
+	})
+}
+
 type testAccDNSRecord struct {
 	Type        string
 	Name        string


### PR DESCRIPTION
## Problem

Two API-identical entries in one `spaceship_dns_records.records` list make `terraform apply` fail with `Provider produced inconsistent result after apply: .records: element 1 has vanished`. The Spaceship API dedups the submitted set to one record while the plan holds two, so the planned set never matches the read-back set and the apply can never converge. Same failure class as the apex-ALIAS fix in 0.5.5: the API accepts the write but stores something else.

Entries count as duplicates however they differ in case (except TXT values, which the API compares case-sensitively) or TTL — the API's identity is type + name + data only.

## Fix

Add `duplicateRecordsValidator`, a `validator.List` on the `records` attribute, that rejects such configs at plan time with an actionable error pointing the later occurrence back at the first. Identity is delegated to the SDK's `client.RecordKey` — the same single source of truth the diff logic uses — so plan-time validation cannot drift from apply-time matching. Elements containing unknown values are skipped: their identity is not computable during plan.

## Tests

- Unit tests cover the matching edge cases: name/data case-folding, TXT case-sensitivity, TTL-only differences, unknown-value skipping, and error placement.
- Acceptance tests (`TestAccDNSRecords_duplicateRecordsFailPlan`, `...CaseFoldedFailPlan`) prove the error surfaces at plan time; both fail the plan before any API write.

## Also included

`fix(deps): bump Go toolchain to 1.26.5` — patches [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) (crypto/tls Encrypted Client Hello privacy leak) flagged by govulncheck in CI, which was blocking this PR. Verified locally: build, unit tests, and `govulncheck ./...` clean on 1.26.5.


## Merge note

Squash-merge with the toolchain bump as an extra conventional-commit line in the commit body so release-please gives it its own changelog entry:

```
fix(records): reject duplicate records in one list at plan time (#115)

fix(deps): bump Go toolchain to 1.26.5 to patch crypto/tls (GO-2026-5856)
```
