### PR TITLE
fix(deps): bump Go toolchain to 1.26.5 to patch crypto/tls (GO-2026-5856)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module terraform-provider-spaceship
 
 go 1.25.9
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.19.0


### PR DESCRIPTION
govulncheck flags [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) (Encrypted Client Hello privacy leak in `crypto/tls`), reachable from the provider's TLS client paths. Fixed in `crypto/tls@go1.26.5`.

The vulnerable code is the standard library compiled into the shipped binary, so this is a releasing `fix(deps):` bump of the `toolchain` directive in `go.mod` — the single pin all workflows follow via `go-version-file`.

Verified locally on 1.26.5: build, unit tests, and `govulncheck ./...` now reports no vulnerabilities.