### PR TITLE
ci: harden release automation (concurrency, pinning, docs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # fetch-depth: 0 pulls the full history and all tags. GoReleaser needs
-      # both to compute the changelog (commits since the previous tag) and to
-      # identify the previous tag itself. The older `git fetch --unshallow`
+      # them to identify the previous tag (the changelog is owned by
+      # release-please, not GoReleaser). The older `git fetch --unshallow`
       # workaround is no longer needed since actions/checkout supports this
       # natively.
       - name: Checkout

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -13,6 +13,13 @@ permissions:
   contents: write
   pull-requests: write
 
+# Two quick merges to master each complete CI and would run release-please
+# concurrently, racing on the release branch/tag. Serialize; never cancel a
+# running release job.
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
@@ -21,7 +28,7 @@ jobs:
       # Generate a token from GitHub App
       - name: Generate GitHub App Token
         id: generate-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.SPS_RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.SPS_RELEASE_PRIVATE_KEY }}
@@ -29,7 +36,7 @@ jobs:
       # Use the generated token in release-please
       - name: Release Please
         id: release
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -59,11 +59,15 @@ At this point nothing is released — the commit simply sits on `master`.
   - updates `CHANGELOG.md` with a generated entry grouped by type,
   - updates `.release-please-manifest.json` with the new version,
   - opens (or updates) a PR titled `chore(master): release X.Y.Z`.
-- Authentication uses a dedicated GitHub App
-  (`SPS_RELEASE_APP_ID`, `SPS_RELEASE_PRIVATE_KEY`), **not** the default
+- Authentication uses a dedicated GitHub App (the `SPS_RELEASE_CLIENT_ID`
+  variable and `SPS_RELEASE_PRIVATE_KEY` secret), **not** the default
   `GITHUB_TOKEN`. This is required: events authored by `GITHUB_TOKEN` do
   not re-trigger workflows, so a token-authored Release PR would never run
-  CI. App-authored events do.
+  CI. App-authored events do. The App installation must grant **Repository
+  contents: Read & write** and **Pull requests: Read & write** — these
+  App-installation scopes (not the workflow's `permissions:` block, which
+  only governs the unused `GITHUB_TOKEN`) gate release-please's branch
+  push, Release PR, tag, and publish operations.
 
 The Release PR is long-lived. As more PRs merge to `master`, release-please
 keeps appending to the same PR, updating the CHANGELOG and (if the bump
@@ -129,7 +133,7 @@ GitHub Release going live.
 
 | Secret | Used by | Purpose |
 |---|---|---|
-| `SPS_RELEASE_APP_ID` | `versioning.yml` | GitHub App ID for release-please |
+| `SPS_RELEASE_CLIENT_ID` (variable, not secret) | `versioning.yml` | GitHub App client ID for release-please |
 | `SPS_RELEASE_PRIVATE_KEY` | `versioning.yml` | GitHub App private key |
 | `GPG_PRIVATE_KEY` | `release.yml` | Signing key for release artifacts |
 | `PASSPHRASE` | `release.yml` | GPG key passphrase |
@@ -144,14 +148,45 @@ GitHub Release going live.
 - Pre-1.0.0: minor versions may contain breaking changes. After 1.0.0,
   standard SemVer rules apply.
 
+## If a release doesn't appear (troubleshooting)
+
+`versioning.yml` only runs after a successful CI run on `master`, and
+release-please state is **cumulative** — every run re-scans all commits since
+the last tag, so a missed trigger delays a release rather than losing it.
+Known cases:
+
+- **CI failed or was flaky on a merge commit** (including the Release PR's
+  own merge commit): re-run the failed CI run — `workflow_run` fires again
+  when a re-run completes — or trigger versioning manually (Actions →
+  Versioning → Run workflow). A merged Release PR whose tag was never created
+  is reconciled the same way on the next successful run.
+- **The commit touched only files CI ignores** (see `paths-ignore` in
+  `ci.yml`): no CI run means no versioning run. The commit is picked up by
+  the next CI-triggering push (weekly Dependabot PRs guarantee one within
+  days) or a manual dispatch. Note the Release PR merge itself always
+  triggers CI — it touches `.release-please-manifest.json`, which is not
+  ignored.
+- **GoReleaser failed after the tag was created** (bad GPG key, upload
+  error): the GitHub Release exists without binaries. The Terraform Registry
+  will not ingest an artifact-less version, so nothing broken is served —
+  fix the cause and re-run the failed `release.yml` run for the tag.
+
 ## Manual / emergency release
 
 Prefer the normal flow. In rare cases (release-please unavailable, out-of-band
 hotfix, etc.) a release can be cut by hand:
 
 1. Bump the version in `.release-please-manifest.json` and add the
-   corresponding entry to `CHANGELOG.md`. Commit to `master`.
-2. Tag the commit: `git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin vX.Y.Z`.
+   corresponding entry to `CHANGELOG.md`. Merge to `master` **before
+   tagging** — if the tag is pushed first, the next release-please run
+   recomputes the same version from the stale manifest and fails on the
+   already-existing tag.
+2. Re-sync so the tag includes the bump commit (`git checkout master &&
+   git pull`), then tag it:
+   `git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin vX.Y.Z`.
 3. `release.yml` runs on the pushed tag and publishes binaries as usual.
+   Caveat: in this path GoReleaser is the release *creator* and its changelog
+   is disabled, so the GitHub Release is published with an **empty body** —
+   edit the Release afterwards and paste the CHANGELOG entry in by hand.
 4. The next release-please run will reconcile its state with the updated
    manifest.


### PR DESCRIPTION
## Why

An automated review of the identical release-please setup in [namecheap/terraform-provider-jenkins#181](https://github.com/namecheap/terraform-provider-jenkins/pull/181) surfaced several findings that apply to this repo — this ports the ones that hold up (the review's "draft release" suggestion was rejected there: draft releases don't create tags, so tag-triggered GoReleaser would never run).

## What

- **`versioning.yml`: concurrency group** (the one behavioral fix) — two quick merges to master each complete CI and run release-please concurrently, racing on the release branch/tag; one run then fails on a git ref-update conflict. `cancel-in-progress: false` so a running release job is never killed.
- **`versioning.yml`: SHA-pin actions** — `create-github-app-token` and `release-please-action` were the only floating tags (`@v3`/`@v5`) among otherwise SHA-pinned workflows.
- **`RELEASE.md`: fix stale credential names** — the doc still referenced `SPS_RELEASE_APP_ID`, dead since the June migration to the `SPS_RELEASE_CLIENT_ID` variable (#77); anyone following the doc would create the wrong secret. Also documents the App-installation scopes release-please needs (contents + PRs Read & write).
- **`RELEASE.md`: troubleshooting section** — flaky-CI-gated versioning runs, `paths-ignore` delays, and GoReleaser failure after tagging: all are delays with a documented recovery (release-please state is cumulative), not lost releases.
- **`RELEASE.md`: manual/emergency path fixes** — merge the manifest bump *before* tagging (stale-manifest tag collision), re-sync before tagging, and the empty-Release-body caveat (GoReleaser's changelog is disabled).
- **`release.yml`: stale comment** — claimed GoReleaser computes the changelog; it's disabled, release-please owns it.