### PR TITLE
ci: remove duplicate concurrency block in versioning workflow

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -19,13 +19,6 @@ concurrency:
 # token generated below.
 permissions: {}
 
-# Two quick merges to master each complete CI and would run release-please
-# concurrently, racing on the release branch/tag. Serialize; never cancel a
-# running release job.
-concurrency:
-  group: release-please-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
   release-please:
     # The workflow_run branch filter matches the run's HEAD branch name, which


### PR DESCRIPTION
## Why

#123 and #124 each added a top-level `concurrency` block to `versioning.yml`. GitHub Actions rejects duplicate keys, so the workflow is currently invalid:

> (Line: 25, Col: 1): 'concurrency' is already defined

## What

Keep the first block (`group: release-please`, `cancel-in-progress: false`) and drop the second. The removed block's `release-please-${{ github.ref }}` group adds nothing: under `workflow_run` the ref is always the default branch, and the plain group also serializes manual `workflow_dispatch` runs against automatic ones.