### PR TITLE
fix(docs): prepare v1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ terraform {
   required_providers {
     spaceship = {
       source  = "registry.terraform.io/namecheap/spaceship"
-      version = ">= 0.4.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/docs/guides/version-1-upgrade.md
+++ b/docs/guides/version-1-upgrade.md
@@ -1,0 +1,60 @@
+---
+page_title: "Upgrading to version 1.0"
+description: |-
+  How to upgrade from a 0.x release to version 1.0 of the Spaceship provider.
+---
+
+# Upgrading to version 1.0
+
+Version 1.0.0 is the first stable release of the Spaceship provider.
+
+**There are no breaking changes.** Version 1.0.0 is functionally identical to
+0.6.0: no resource or data source schemas changed, no attributes were renamed
+or removed, and no state migration is required. Existing configurations and
+state files continue to work as-is — upgrading is a version-constraint change
+and nothing more.
+
+## Upgrade steps
+
+Update the provider version constraint in your configuration:
+
+```terraform
+terraform {
+  required_providers {
+    spaceship = {
+      source  = "namecheap/spaceship"
+      version = "~> 1.0"
+    }
+  }
+}
+```
+
+Then upgrade the locked provider version and verify:
+
+```shell
+terraform init -upgrade
+terraform plan
+```
+
+`terraform plan` should report no changes for a configuration that was
+in sync before the upgrade.
+
+## Stability and testing
+
+The 1.0.0 release was validated end-to-end against the live Spaceship API:
+every resource and data source was exercised through its full
+plan / apply / import / destroy lifecycle, including rate-limit handling,
+record matching edge cases, and out-of-band drift detection. The release ships
+only after that validation reported no functional defects.
+
+## Semantic versioning commitment
+
+From 1.0.0 onward the provider follows [Semantic Versioning](https://semver.org/):
+
+- **Patch releases** (`1.0.x`) contain only bug fixes.
+- **Minor releases** (`1.x.0`) add functionality in a backwards-compatible way.
+- **Breaking changes** ship only in a new **major release**, with an upgrade
+  guide like this one.
+
+The `~> 1.0` constraint above therefore tracks all 1.x releases safely while
+protecting you from a future major version until you opt in.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     spaceship = {
       source  = "namecheap/spaceship"
-      version = ">= 0.4.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/docs/resources/dns_records.md
+++ b/docs/resources/dns_records.md
@@ -43,16 +43,16 @@ resource "spaceship_dns_records" "example" {
       preference = 10
     },
     {
-      type       = "ALIAS"
-      name       = "@"
-      ttl        = 3600
-      alias_name = "origin.example.com"
-    },
-    {
       type  = "CNAME"
       name  = "www"
       ttl   = 3600
       cname = "example.com"
+    },
+    {
+      type       = "ALIAS"
+      name       = "docs"
+      ttl        = 3600
+      alias_name = "origin.example.com"
     },
     {
       type  = "TXT"

--- a/docs/resources/personal_nameserver.md
+++ b/docs/resources/personal_nameserver.md
@@ -12,6 +12,8 @@ Manages a single personal nameserver host (a registry glue record) for a Spacesh
 
 ~> **Warning:** `host` is a label relative to `domain`, not a fully qualified name. The API accepts an FQDN such as `ns1.example.com` and silently creates the glue host `ns1.example.com.example.com`. The provider does not reject this, because dotted labels (e.g. `ns1.sub` → `ns1.sub.example.com`) are valid input — double-check that `host` does not already include the domain.
 
+-> **Note:** API requests throttled by Spaceship are retried automatically until the operation timeout elapses. Use the `timeouts` block to bound how long each operation may wait.
+
 ## Example Usage
 
 ```terraform

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     spaceship = {
       source  = "namecheap/spaceship"
-      version = ">= 0.4.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/examples/resources/spaceship_dns_records/resource.tf
+++ b/examples/resources/spaceship_dns_records/resource.tf
@@ -22,16 +22,16 @@ resource "spaceship_dns_records" "example" {
       preference = 10
     },
     {
-      type       = "ALIAS"
-      name       = "@"
-      ttl        = 3600
-      alias_name = "origin.example.com"
-    },
-    {
       type  = "CNAME"
       name  = "www"
       ttl   = 3600
       cname = "example.com"
+    },
+    {
+      type       = "ALIAS"
+      name       = "docs"
+      ttl        = 3600
+      alias_name = "origin.example.com"
     },
     {
       type  = "TXT"

--- a/templates/guides/version-1-upgrade.md.tmpl
+++ b/templates/guides/version-1-upgrade.md.tmpl
@@ -1,0 +1,60 @@
+---
+page_title: "Upgrading to version 1.0"
+description: |-
+  How to upgrade from a 0.x release to version 1.0 of the Spaceship provider.
+---
+
+# Upgrading to version 1.0
+
+Version 1.0.0 is the first stable release of the Spaceship provider.
+
+**There are no breaking changes.** Version 1.0.0 is functionally identical to
+0.6.0: no resource or data source schemas changed, no attributes were renamed
+or removed, and no state migration is required. Existing configurations and
+state files continue to work as-is — upgrading is a version-constraint change
+and nothing more.
+
+## Upgrade steps
+
+Update the provider version constraint in your configuration:
+
+```terraform
+terraform {
+  required_providers {
+    spaceship = {
+      source  = "namecheap/spaceship"
+      version = "~> 1.0"
+    }
+  }
+}
+```
+
+Then upgrade the locked provider version and verify:
+
+```shell
+terraform init -upgrade
+terraform plan
+```
+
+`terraform plan` should report no changes for a configuration that was
+in sync before the upgrade.
+
+## Stability and testing
+
+The 1.0.0 release was validated end-to-end against the live Spaceship API:
+every resource and data source was exercised through its full
+plan / apply / import / destroy lifecycle, including rate-limit handling,
+record matching edge cases, and out-of-band drift detection. The release ships
+only after that validation reported no functional defects.
+
+## Semantic versioning commitment
+
+From 1.0.0 onward the provider follows [Semantic Versioning](https://semver.org/):
+
+- **Patch releases** (`1.0.x`) contain only bug fixes.
+- **Minor releases** (`1.x.0`) add functionality in a backwards-compatible way.
+- **Breaking changes** ship only in a new **major release**, with an upgrade
+  guide like this one.
+
+The `~> 1.0` constraint above therefore tracks all 1.x releases safely while
+protecting you from a future major version until you opt in.

--- a/templates/resources/personal_nameserver.md.tmpl
+++ b/templates/resources/personal_nameserver.md.tmpl
@@ -12,6 +12,8 @@ description: |-
 
 ~> **Warning:** `host` is a label relative to `domain`, not a fully qualified name. The API accepts an FQDN such as `ns1.example.com` and silently creates the glue host `ns1.example.com.example.com`. The provider does not reject this, because dotted labels (e.g. `ns1.sub` → `ns1.sub.example.com`) are valid input — double-check that `host` does not already include the domain.
 
+-> **Note:** API requests throttled by Spaceship are retried automatically until the operation timeout elapses. Use the `timeouts` block to bound how long each operation may wait.
+
 ## Example Usage
 
 {{ tffile .ExampleFile }}


### PR DESCRIPTION
Documentation-only changes gating the v1.0.0 tag, closing out the remaining findings from the 0.6.0 re-validation round:

- Switch the copy-paste version constraint from `>= 0.4.0` to `~> 1.0` in `README.md`, `docs/index.md`, and `examples/provider/provider.tf`, so `terraform init` cannot select a future breaking major.
- Fix the `spaceship_dns_records` example: the apex ALIAS entry (now rejected at plan time) is moved to a non-apex name, so the primary example applies cleanly and the ALIAS type stays documented.
- Add the automatic-retry-on-throttling note to the personal nameserver resource page (previously only on the domain resource).
- Add a **v1.0 upgrade guide** (`docs/guides/version-1-upgrade.md`): no breaking changes, validated end-to-end against the live API, and a semantic-versioning commitment from 1.0.0 onward.

## Release mechanics

The commit carries a `Release-As: 1.0.0` footer so release-please proposes v1.0.0 without a fabricated breaking-change entry.

**When squash-merging, keep the `Release-As: 1.0.0` line in the squash commit body** — release-please reads it from the commit on `master`. After merge, the Release PR it opens should target 1.0.0; merging that Release PR creates the `v1.0.0` tag and GoReleaser publishes it.