### PR TITLE
ci: gate CI jobs on changed paths to skip redundant acceptance runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,19 @@
 name: CI
 
+# No workflow-level paths-ignore here, on purpose. If this workflow does not
+# trigger at all, two things break: (1) required status checks are never
+# reported on PRs that touch only excluded files, which blocks them from
+# merging permanently, and (2) versioning.yml's `workflow_run: [CI]` trigger
+# never fires on pushes that touch only release files, stalling the
+# release-please -> tag -> GoReleaser chain. Instead, the `changes` job below
+# detects what changed and the expensive jobs skip themselves via `if:` —
+# skipped checks DO satisfy branch protection, and the workflow still
+# completes so workflow_run still fires. See CI.md.
 on:
     push:
         branches:
             - master
-        paths-ignore:
-            - "**.md"
-            - "LICENSE"
-            - "CLAUDE.md"
-            - "AGENTS.md"
-            - ".github/ISSUE_TEMPLATE/**"
-            - ".github/pull_request_template.md"
     pull_request:
-        paths-ignore:
-            - "**.md"
-            - "LICENSE"
-            - "CLAUDE.md"
-            - "AGENTS.md"
-            - ".github/ISSUE_TEMPLATE/**"
-            - ".github/pull_request_template.md"
 
 # Least-privilege default: CI only reads the repo. Codecov uses its own token
 # (CODECOV_TOKEN secret), and upload-artifact does not require write perms.
@@ -26,9 +21,49 @@ permissions:
     contents: read
 
 jobs:
+    # Gate job: decides whether the jobs below actually need to run for this
+    # change. `code` is false only when the diff touches nothing but
+    # root-level markdown (README/CHANGELOG/CLAUDE.md/...), LICENSE, or the
+    # release-please manifest — most notably the release-please Release PR
+    # (CHANGELOG.md + .release-please-manifest.json) and its merge to master,
+    # which previously re-ran the full acceptance suite twice per release on
+    # code that was already tested. docs/** and templates/** deliberately
+    # count as code: docs/ is published to the Terraform Registry at each
+    # release tag, so doc changes get the full pipeline like any user-visible
+    # change.
+    changes:
+        name: Detect Changes
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: read # paths-filter reads PR files via the API on pull_request events
+        outputs:
+            code: ${{ steps.filter-code.outputs.code }}
+        steps:
+            # Checkout is required for push events, where paths-filter diffs
+            # with git (pull_request events use the API and would not need it).
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+            # With predicate-quantifier=every a file counts as `code` only if
+            # it matches ALL patterns, i.e. it is none of the ignored kinds.
+            # `*.md` (no globstar) matches root-level markdown only, so nested
+            # markdown — docs/**, templates/** — still counts as code on
+            # purpose.
+            - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+              id: filter-code
+              with:
+                  predicate-quantifier: "every"
+                  filters: |
+                      code:
+                          - '!*.md'
+                          - '!LICENSE'
+                          - '!.release-please-manifest.json'
+
     check:
         name: Check
         runs-on: ubuntu-latest
+        needs: changes
+        if: needs.changes.outputs.code == 'true'
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
             - name: Set up Go
@@ -109,6 +144,8 @@ jobs:
         # tooling can consume an inventory without re-running the scan.
         name: Security scan (Trivy)
         runs-on: ubuntu-latest
+        needs: changes
+        if: needs.changes.outputs.code == 'true'
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -188,6 +225,8 @@ jobs:
         # advisory DB is fetched fresh each run.
         name: Security scan (govulncheck)
         runs-on: ubuntu-latest
+        needs: changes
+        if: needs.changes.outputs.code == 'true'
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -231,9 +270,12 @@ jobs:
         # pass/fail is taken verbatim from the gate jobs (needs.*.result), so a
         # green comment can never mask a red gate.
         name: Security scan summary
-        needs: [security, govulncheck]
-        # Run even when a gate above failed — that's when the summary matters most.
-        if: ${{ !cancelled() }}
+        needs: [changes, security, govulncheck]
+        # Run even when a scan above failed — that's when the summary matters
+        # most. `!cancelled()` alone would also run when the `changes` gate
+        # skipped the scans (status-check functions override the implicit
+        # success() on needs), so the gate output is re-checked explicitly.
+        if: ${{ !cancelled() && needs.changes.outputs.code == 'true' }}
         runs-on: ubuntu-latest
         permissions:
             contents: read # checkout + read go.mod for the dependency overview
@@ -308,7 +350,13 @@ jobs:
 
     acceptance:
         name: Acceptance Tests
-        needs: check
+        needs: [changes, check]
+        # The implicit success() still applies alongside this expression, so
+        # the job keeps requiring `check` to pass. The acceptance-secrets
+        # probe stays step-level (see below): when secrets are absent (fork /
+        # Dependabot PRs) the job still runs and passes with all steps
+        # skipped, exactly as before.
+        if: needs.changes.outputs.code == 'true'
         runs-on: ubuntu-latest
         concurrency:
             group: acceptance-tests
@@ -351,3 +399,25 @@ jobs:
                   SPACESHIP_TEST_DOMAIN: ${{ secrets.SPACESHIP_TEST_DOMAIN }}
                   TF_ACC: 1
               run: make testacc
+
+    # Always-run summary job with two purposes:
+    # 1. A workflow run whose jobs were ALL skipped by the gate would
+    #    otherwise have no executed job, making the run-level conclusion
+    #    (which gates versioning.yml via workflow_run) ambiguous. This job
+    #    always executes, so the run always concludes success or failure.
+    # 2. Branch protection can require just this one check instead of listing
+    #    every job: it fails if any needed job failed or was cancelled, and
+    #    passes when jobs succeeded or were legitimately skipped by the gate.
+    # Every job in this workflow must be listed in `needs` below.
+    ci-ok:
+        name: CI OK
+        runs-on: ubuntu-latest
+        needs: [changes, check, security, govulncheck, security-report, acceptance]
+        if: always()
+        steps:
+            - name: Check results of all jobs
+              env:
+                  NEEDS: ${{ toJSON(needs) }}
+              run: |
+                  echo "$NEEDS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+                  echo "$NEEDS" | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")' > /dev/null

--- a/CI.md
+++ b/CI.md
@@ -1,0 +1,135 @@
+# CI and release pipeline
+
+Human-oriented map of how a change travels from a pull request to a published
+release, and why the pipeline skips work it doesn't need. For the
+release/registry runbook see [RELEASE.md](RELEASE.md); this document covers
+the CI mechanics.
+
+## Workflows at a glance
+
+| Workflow | File | Trigger | Purpose |
+|---|---|---|---|
+| CI | `.github/workflows/ci.yml` | PR, push to `master` | Lint, unit tests + coverage floor, docs drift/schema checks, Trivy and govulncheck security gates, acceptance tests |
+| CodeQL | `.github/workflows/codeql.yml` | PR, push to `master`, weekly cron | Static security analysis (Go) |
+| PR Title Check | `.github/workflows/pr-title.yml` | PR | Enforces Conventional Commit PR titles (they become the squash-commit messages release-please reads) |
+| Versioning | `.github/workflows/versioning.yml` | After every CI run on `master` (`workflow_run`), manual | release-please: opens/updates the Release PR; creates the tag when it merges |
+| Release | `.github/workflows/release.yml` | Push of a `v*` tag | GoReleaser: builds, signs and publishes binaries |
+
+(`.github/dco.yml` configures the DCO app; it is not a workflow.)
+
+## Life of a change
+
+```mermaid
+flowchart TD
+    A[Feature PR opened] -->|CI: full run| B[Squash-merge to master]
+    B -->|CI: full run| C[Versioning opens/updates Release PR]
+    C -->|CI: gate skips all test jobs| D[Maintainer merges Release PR]
+    D -->|CI: gate skips all test jobs| E[Versioning creates vX.Y.Z tag]
+    E -->|Release workflow| F[GoReleaser publishes signed binaries]
+    F --> G[Terraform Registry indexes the version]
+```
+
+A single code change used to run the full pipeline — including the acceptance
+suite against the **real Spaceship API** — **four** times on its way to a
+release (PR, merge, Release PR, Release PR merge). The `changes` gate in
+`ci.yml` cuts that to the two runs that test something new: the Release PR
+only touches `CHANGELOG.md` and `.release-please-manifest.json`, so re-testing
+the already-merged code there added runner time and real API/rate-limit load
+(acceptance runs are serialized via the `acceptance-tests` concurrency group,
+so redundant runs also queue behind useful ones) but no signal.
+
+## The changes gate
+
+The first job in CI, `changes`, uses
+[dorny/paths-filter](https://github.com/dorny/paths-filter) to classify the
+diff, and every other job declares `needs: changes` plus an `if:` condition
+on its `code` output. `code` is false **only** when the diff touches nothing
+but root-level markdown (`README.md`, `CHANGELOG.md`, `CLAUDE.md`, ...),
+`LICENSE`, or `.release-please-manifest.json`. Everything else — including
+`docs/**` and `templates/**` — counts as code: `docs/` is published to the
+Terraform Registry at each release tag and is user-visible, so doc changes
+get the full pipeline like any other change. (The old workflow-level
+`paths-ignore` used `**.md`, which skipped CI entirely for registry-published
+docs — hand-edits to `docs/` could land unverified. The gate deliberately
+closes that hole.)
+
+What runs for typical changes:
+
+| Change | Check / Security / govulncheck / Summary / Acceptance | CI OK |
+|---|---|---|
+| Go code, workflows, examples, scripts | runs | ✅ |
+| `docs/**` or `templates/**` (registry-published docs) | runs | ✅ |
+| README / CHANGELOG / CLAUDE.md / LICENSE only | skipped | ✅ |
+| Release PR (changelog + manifest) | skipped | ✅ |
+
+Independent of the gate, the Acceptance Tests job silently no-ops (all steps
+skip, job passes) when the `SPACESHIP_*` secrets are unavailable — e.g. on
+fork or Dependabot PRs. That probe is step-level and unchanged by the gate.
+
+### Why a gate job instead of workflow-level `paths-ignore`
+
+`paths-ignore` on the workflow trigger looks simpler but breaks two things:
+
+1. **Required checks are never reported on filtered PRs.** If branch
+   protection requires a CI check and the workflow doesn't trigger at all,
+   the check stays "Expected" forever and a docs-only PR can never be merged.
+   A job skipped by an `if:` condition, by contrast, reports "skipped" —
+   which **does** satisfy branch protection.
+2. **The release chain dies.** `versioning.yml` triggers on
+   `workflow_run: [CI]`. If a push to `master` doesn't start CI at all, that
+   event never fires — release-please wouldn't run and a pending release
+   would stall until the next CI-triggering push. With the gate, CI always
+   runs (its jobs just skip), so `workflow_run` always fires.
+
+### The CI OK job
+
+`ci-ok` runs `if: always()`, checks every other job's result, and fails if
+any of them failed or was cancelled ("skipped" is fine). It exists because:
+
+- a run whose jobs were **all** skipped needs at least one executed job for
+  the run-level conclusion — which gates Versioning — to be a deterministic
+  `success`;
+- **"CI OK" should be the required status check** in the master ruleset.
+  Individual job checks alone cannot be relied on: if the `changes` gate job
+  itself *fails* (API flake, runner loss), every test job is `skipped`, and
+  skipped checks satisfy branch protection — a failing "CI OK" is the only
+  thing that blocks such a PR from merging untested.
+
+## How docs reach the Terraform Registry
+
+`docs/` is **not** shipped inside the GoReleaser artifacts. When GoReleaser
+publishes the GitHub Release for a `vX.Y.Z` tag, the Terraform Registry
+webhook ingests the release and renders documentation by reading the
+repository **at that git tag** — `docs/index.md`, `docs/resources/*`,
+`docs/data-sources/*` become that version's docs pages. Consequences:
+
+- A docs change merged to `master` is invisible to registry users until the
+  next release tag; each published version keeps the docs as of its tag.
+- **Commit-type convention** (see [CLAUDE.md](CLAUDE.md)): corrections to
+  registry-published docs — the `docs/` tree and the `templates/` that
+  generate it — are typed **`fix(docs):`** so release-please treats them as
+  releasing changes and cuts a patch release. Repo-internal markdown
+  (README, `RELEASE.md`, `CI.md`, `CLAUDE.md`) stays plain `docs:`, which
+  does not release.
+- `docs/` is autogenerated by `make docs` from `templates/` and the provider
+  schema; the Check job fails the build if the committed `docs/` doesn't
+  match the generated output (`make docs` diff + `make docs-validate`).
+
+## Editing the pipeline — invariants to keep
+
+- **Don't add `paths`/`paths-ignore` to `ci.yml` triggers** (see above).
+  `codeql.yml` still carries a `paths-ignore` today; that is tolerable only
+  while its check is not required by the ruleset — remove it before ever
+  making "Analyze" a required check.
+- **Keep `ci-ok` in `needs` sync**: every job added to `ci.yml` must also be
+  added to the `ci-ok` `needs:` list — "CI OK" only guards the jobs it
+  watches.
+- **New jobs should take the gate**: `needs: changes` +
+  `if: needs.changes.outputs.code == 'true'`. A job that must run even when
+  its needs failed or skipped (like the security summary) has to re-check
+  `needs.changes.outputs.code` explicitly, because status-check functions
+  (`always()`, `!cancelled()`) override the implicit `success()`.
+- **The gate's ignore list must stay a subset of "files that can't affect
+  the binary, tests, or published docs"** — when in doubt, let the jobs run.
+  In particular `docs/**` must never be added to it: registry-published
+  documentation is a user-visible deliverable.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@ Three workflows participate:
 
 | Workflow | Trigger | Role |
 |---|---|---|
-| [`ci.yml`](.github/workflows/ci.yml) | push to `master`, PRs | Lint, unit tests, coverage threshold, doc validation, optional acceptance tests |
+| [`ci.yml`](.github/workflows/ci.yml) | push to `master`, PRs | Lint, unit tests, coverage threshold, doc validation, security scans, optional acceptance tests — jobs are gated on changed paths, see [CI.md](CI.md) |
 | [`versioning.yml`](.github/workflows/versioning.yml) | `ci.yml` success on `master`, manual dispatch | Runs release-please to open/update the Release PR |
 | [`release.yml`](.github/workflows/release.yml) | push of a `v*` tag | Runs GoReleaser to build, sign, and publish artifacts |
 
@@ -160,12 +160,12 @@ Known cases:
   when a re-run completes — or trigger versioning manually (Actions →
   Versioning → Run workflow). A merged Release PR whose tag was never created
   is reconciled the same way on the next successful run.
-- **The commit touched only files CI ignores** (see `paths-ignore` in
-  `ci.yml`): no CI run means no versioning run. The commit is picked up by
-  the next CI-triggering push (weekly Dependabot PRs guarantee one within
-  days) or a manual dispatch. Note the Release PR merge itself always
-  triggers CI — it touches `.release-please-manifest.json`, which is not
-  ignored.
+- **The commit touched only docs-like files** (root-level markdown,
+  `LICENSE`, the release-please manifest): CI still runs — its `changes`
+  gate skips the test jobs, but the always-run `CI OK` job completes the
+  workflow with `success`, so versioning fires as usual (see
+  [CI.md](CI.md)). Unlike the old workflow-level `paths-ignore`, this can
+  no longer stall a release.
 - **GoReleaser failed after the tag was created** (bad GPG key, upload
   error): the GitHub Release exists without binaries. The Terraform Registry
   will not ingest an artifact-less version, so nothing broken is served —


### PR DESCRIPTION
## Why

A single code change currently runs the full pipeline — including the acceptance suite against the **real Spaceship API** — **4 times** on its way to a release: on the PR, on its merge to `master`, on the release-please Release PR, and on that PR's merge — although the Release PR only touches `CHANGELOG.md` and `.release-please-manifest.json`. Two of the four runs re-test code that was already tested, burning runner time and real API/rate-limit budget (acceptance runs are serialized via the `acceptance-tests` concurrency group, so redundant runs also queue behind useful ones). Tracked in DEVOPS-21842.

## What

- Replaces workflow-level `paths-ignore` in `ci.yml` with a `changes` gate job (`dorny/paths-filter@v4.0.2`, pinned by SHA, `predicate-quantifier: every`). Check/Trivy/govulncheck/summary/Acceptance skip when the diff touches only root-level markdown (`*.md`), `LICENSE`, or `.release-please-manifest.json`.
- `docs/**` and `templates/**` are treated as code and run the full suite: docs are rendered by the Terraform Registry from the repo at each release tag, so they are a user-visible deliverable. The old `**.md` ignore skipped CI entirely for them, letting hand-edits to generated docs land unverified — this closes that hole and matches the `fix(docs):` convention already documented in `CLAUDE.md`. (Side effect: `.github/ISSUE_TEMPLATE/**` and the PR template also count as code now — a conservative trade for a simpler, safer ignore list.)
- The `security-report` job re-checks the gate output explicitly (`!cancelled() && needs.changes.outputs.code == 'true'`): its status-check function would otherwise override the implicit `success()` and run it even when the scans were skipped. It still runs when a scan *fails*, which is when the summary matters most.
- The Acceptance job's step-level secrets probe is untouched: without `SPACESHIP_*` secrets (fork/Dependabot PRs) the job still runs and passes with all steps skipped, exactly as before.
- Adds an always-run `CI OK` summary job (fails on any failed/cancelled job, passes on success/skipped) so a fully-skipped run still concludes `success` — required by `versioning.yml`'s `workflow_run` gate — and can serve as a single required check.
- Adds `CI.md` (human-oriented pipeline description) and updates the now-outdated `RELEASE.md` troubleshooting entry about ignored paths.

## Why not just keep `paths-ignore`

1. A path-filtered required check is never reported on PRs touching only excluded files — once any CI check becomes required, a docs-only PR could never merge. Jobs skipped via `if:` report "skipped", which **does** satisfy branch protection.
2. `versioning.yml` triggers on `workflow_run: [CI]` with `conclusion == 'success'`. If CI didn't trigger on a push at all, that event would never fire and release-please would stall until the next CI-triggering push. With the gate, CI always runs and always concludes.

## Branch protection

The "Protect master branch" ruleset currently has **no required status checks** (only 1 approving review with last-push approval, linear history, and deletion/force-push protection). After this merges, **"CI OK" should be added as a required status check** — and it must be that job specifically, not the individual ones: if the `changes` gate job itself fails (API flake, runner loss), every test job reports "skipped", and skipped checks satisfy branch protection — a failing "CI OK" is the only check that would block such an untested merge.

## Verification

- `actionlint` (v1.7.10) passes on all workflows.
- This PR itself exercises the `code=true` path (workflow + root-md changes → full suite runs).
- The next release-please PR will exercise the skip path; expect all test jobs "skipped" and "CI OK" green there, and a normal Versioning → tag → GoReleaser run after its merge.
