### PR TITLE
ci: harden the CI OK gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,24 +400,50 @@ jobs:
                   TF_ACC: 1
               run: make testacc
 
-    # Always-run summary job with two purposes:
+    # Summary job with two purposes:
     # 1. A workflow run whose jobs were ALL skipped by the gate would
     #    otherwise have no executed job, making the run-level conclusion
     #    (which gates versioning.yml via workflow_run) ambiguous. This job
-    #    always executes, so the run always concludes success or failure.
+    #    executes on every run that isn't cancelled, so the run always
+    #    concludes success/failure. `!cancelled()` rather than `always()`:
+    #    a superseded PR run cancelled by the concurrency group skips this
+    #    job instead of spending a runner to post a red check on a dead SHA
+    #    (checks are evaluated per-SHA, so the replacement run supplies the
+    #    required check).
     # 2. Branch protection can require just this one check instead of listing
     #    every job: it fails if any needed job failed or was cancelled, and
     #    passes when jobs succeeded or were legitimately skipped by the gate.
-    # Every job in this workflow must be listed in `needs` below.
+    # Every job in this workflow must be listed in `needs` below; the first
+    # step asserts that, so a job missing from the list fails this check
+    # instead of silently escaping it.
     ci-ok:
         name: CI OK
         runs-on: ubuntu-latest
         needs: [changes, check, security, govulncheck, security-report, acceptance]
-        if: always()
+        if: ${{ !cancelled() }}
         steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+            # "CI OK" only guards the jobs listed in its `needs`. A job added
+            # to the workflow but not to that list could fail without turning
+            # this check red — the exact gap this job exists to close — so
+            # assert the two lists match instead of relying on the note in
+            # CI.md.
+            - name: Assert every job is watched by this gate
+              run: |
+                  watched=$(yq '.jobs.ci-ok.needs[]' .github/workflows/ci.yml | sort)
+                  all=$(yq '.jobs | keys | .[]' .github/workflows/ci.yml | grep -vx 'ci-ok' | sort)
+                  if ! diff <(echo "$all") <(echo "$watched"); then
+                    echo "::error::ci.yml jobs and ci-ok's needs list have drifted (< missing from needs, > stale entry)."
+                    exit 1
+                  fi
+
             - name: Check results of all jobs
               env:
                   NEEDS: ${{ toJSON(needs) }}
               run: |
                   echo "$NEEDS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
-                  echo "$NEEDS" | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")' > /dev/null
+                  if ! echo "$NEEDS" | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")' > /dev/null; then
+                    echo "::error::One or more CI jobs failed or were cancelled — see the results above."
+                    exit 1
+                  fi

--- a/CI.md
+++ b/CI.md
@@ -83,8 +83,12 @@ fork or Dependabot PRs. That probe is step-level and unchanged by the gate.
 
 ### The CI OK job
 
-`ci-ok` runs `if: always()`, checks every other job's result, and fails if
-any of them failed or was cancelled ("skipped" is fine). It exists because:
+`ci-ok` runs on every non-cancelled run (`if: ${{ !cancelled() }}` — a
+superseded PR run cancelled by the concurrency group skips it instead of
+posting a red check on a dead SHA), checks every other job's result, and
+fails if any of them failed or was cancelled ("skipped" is fine). It also
+asserts that its own `needs:` list matches the workflow's job list, so a
+newly added job can't silently escape its watch. It exists because:
 
 - a run whose jobs were **all** skipped needs at least one executed job for
   the run-level conclusion — which gates Versioning — to be a deterministic
@@ -123,7 +127,8 @@ repository **at that git tag** — `docs/index.md`, `docs/resources/*`,
   making "Analyze" a required check.
 - **Keep `ci-ok` in `needs` sync**: every job added to `ci.yml` must also be
   added to the `ci-ok` `needs:` list — "CI OK" only guards the jobs it
-  watches.
+  watches. This is enforced — `ci-ok`'s first step diffs its `needs:`
+  against the workflow's job list and fails on drift.
 - **New jobs should take the gate**: `needs: changes` +
   `if: needs.changes.outputs.code == 'true'`. A job that must run even when
   its needs failed or skipped (like the security summary) has to re-check


### PR DESCRIPTION
Ports the review hardening accepted on [jenkins#200](https://github.com/namecheap/terraform-provider-jenkins/pull/200) (review by @kurok) to this repo's gate:

- **`if: ${{ !cancelled() }}` instead of `always()`** — identical blocking on failure (`cancelled()` is a status function, so the implicit `success()` stays suppressed), but a superseded PR run cancelled by the concurrency group no longer spends a runner posting a red "CI OK" on a dead SHA.
- **Needs-drift assertion** — `ci-ok`'s first step diffs its `needs:` list against the workflow's job list and fails on drift, turning CI.md's documented keep-in-sync invariant into an enforced one.
- **`::error` annotations** — gate failures now state the reason on the checks UI instead of exiting silently.

yq expressions verified against mikefarah yq v4.44.3 (the build on ubuntu-latest); the original suggestion's `yq -r` belongs to the Python jq-wrapper yq and would have failed. Same change is applied to [namecheap#315](https://github.com/namecheap/terraform-provider-namecheap/pull/315).

Tracked in DEVOPS-21842.